### PR TITLE
Passing protractor exit code through.  Tests

### DIFF
--- a/cli/e2e.js
+++ b/cli/e2e.js
@@ -32,7 +32,7 @@ function getProtractorConfigPath() {
  * Handles killing off the selenium and webpack servers.
  * @name killServers
  */
-function killServers() {
+function killServers(exitCode) {
 
   logger.info('Cleaning up running servers');
   if (seleniumServer) {
@@ -45,7 +45,8 @@ function killServers() {
     webpackServer.close();
   }
 
-  process.exit(0);
+  console.log(`Exiting process with ${exitCode}`);
+  process.exit(exitCode || 0);
 }
 
 /**
@@ -124,9 +125,7 @@ function e2e(argv) {
   seleniumServer = null;
 
   // Politely kill any of our servers
-  process.on('SIGINT', () => {
-    killServers();
-  });
+  process.on('SIGINT', killServers);
 
   // Allows serve to be run independently
   if (argv.noServe) {

--- a/test/cli-e2e.spec.js
+++ b/test/cli-e2e.spec.js
@@ -152,7 +152,7 @@ describe('cli e2e', () => {
     expect(logger.info).toHaveBeenCalledTimes(2);
   });
 
-  it('should listen for SIGINT and kill the servers', () => {
+  it('should listen for SIGINT and kill the servers, defaulting to exit code 0', () => {
     spyOn(process, 'on').and.callFake((evt, cb) => {
       if (evt === 'SIGINT') {
         cb();
@@ -160,6 +160,16 @@ describe('cli e2e', () => {
     });
     require('../cli/e2e')({ noServe: true });
     expect(process.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('should pass through any exit code', () => {
+    spyOn(process, 'on').and.callFake((evt, cb) => {
+      if (evt === 'SIGINT') {
+        cb(1337);
+      }
+    });
+    require('../cli/e2e')({ noServe: true });
+    expect(process.exit).toHaveBeenCalledWith(1337);
   });
 
 });


### PR DESCRIPTION
Fixes a bug @Blackbaud-JonathanBell pointed out, where e2e command doesn't "fail the build."