### PR TITLE
Updated rxjs version due to issue with extending http class.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "raw-loader": "0.5.1",
     "reflect-metadata": "0.1.3",
     "remap-istanbul": "devCrossNet/remap-istanbul",
-    "rxjs": "5.0.3",
+    "rxjs": "5.1.0",
     "sass-loader": "4.0.2",
     "selenium-standalone": "5.6.2",
     "source-map-inline-loader": "blackbaud-bobbyearl/source-map-inline-loader",


### PR DESCRIPTION
- Open `skyuxconfig.json` and add `"auth": true`. Build should fail.