### PR TITLE
Wrote failing test.  Fixed bug.  Test passes for opening host url with base twice

### DIFF
--- a/config/webpack/serve.webpack.config.js
+++ b/config/webpack/serve.webpack.config.js
@@ -38,7 +38,7 @@ function getWebpackConfig(argv, skyPagesConfig) {
         );
 
         const hostUrl = hostUtils.resolve(
-          skyPagesConfigUtil.getAppBase(skyPagesConfig),
+          '',
           localUrl,
           stats.toJson().chunks,
           skyPagesConfig

--- a/test/config-webpack-serve.spec.js
+++ b/test/config-webpack-serve.spec.js
@@ -90,7 +90,7 @@ describe('config webpack serve', () => {
     expect(logger.info).toHaveBeenCalledTimes(2);
   });
 
-  it('should log the host url and launch it when open flag is not present', () => {
+  it('should log the host url and launch it when launch flag is not present', () => {
     config.plugins.forEach(plugin => {
       if (plugin.name === 'WebpackPluginDone') {
         plugin.apply({
@@ -109,7 +109,9 @@ describe('config webpack serve', () => {
     });
 
     expect(logger.info).toHaveBeenCalledTimes(2);
-    expect(openCalledWith).toContain('https://my-host-server.url');
+    expect(openCalledWith).toContain(
+      'https://my-host-server.url/@blackbaud/skyux-builder/?local=true&_cfg='
+    );
   });
 
   it('should log the host url and launch it when --launch host', () => {


### PR DESCRIPTION
Currently, `skyux serve` will open the host url but include the app base twice.  This is caused due to updates to `host-utils`.

I first updated my test to fail in it's current state (making what url I test is opened more strict).  Then fixed the bug and have the test pass.