### PR TITLE
Exposing SkyuxConfigProvider and SkyuxConfig

### DIFF
--- a/config/webpack/common.webpack.config.js
+++ b/config/webpack/common.webpack.config.js
@@ -83,6 +83,11 @@ function getWebpackConfig(skyPagesConfig) {
       rules: [
         {
           enforce: 'pre',
+          test: /skyux-config\.ts$/,
+          loader: outPath('loader', 'skyux-config-module')
+        },
+        {
+          enforce: 'pre',
           test: /sky-pages\.module\.ts$/,
           loader: outPath('loader', 'sky-pages-module')
         },
@@ -107,13 +112,13 @@ function getWebpackConfig(skyPagesConfig) {
         name: ['skyux', 'vendor', 'polyfills']
       }),
       new webpack.DefinePlugin({
-        'SKY_PAGES': JSON.stringify(skyPagesConfig)
+        'SKYUX_CONFIG': JSON.stringify(skyPagesConfig)
       }),
       new ProgressBarPlugin(),
       failPlugin,
       new LoaderOptionsPlugin({
         options: {
-          SKY_PAGES: skyPagesConfig
+          SKYUX_CONFIG: skyPagesConfig
         }
       }),
       new ContextReplacementPlugin(

--- a/lib/sky-pages-bootstrap-generator.js
+++ b/lib/sky-pages-bootstrap-generator.js
@@ -8,7 +8,7 @@ function getBootstrap(skyPagesConfig) {
     bootstrap =
 `import { SkyAppBootstrapper } from '${skyPagesConfig.runtimeAlias}';
 
-SKY_PAGES.bootstrapConfig = SkyAppBootstrapper.bootstrapConfig = {
+SKYUX_CONFIG.bootstrapConfig = SkyAppBootstrapper.bootstrapConfig = {
   omnibar: ${JSON.stringify(skyPagesConfig.omnibar)},
   auth: ${JSON.stringify(skyPagesConfig.auth)},
   help: ${JSON.stringify(skyPagesConfig.help)},

--- a/lib/sky-pages-module-generator.js
+++ b/lib/sky-pages-module-generator.js
@@ -38,22 +38,28 @@ function getSource(skyPagesConfig) {
   const routes = routeGenerator.getRoutes(skyPagesConfig);
   const names = `${componentNames.concat(routes.names).join(',\n    ')}`;
 
-  let authHttpImport = '';
-  let authHttpProvider = '';
+  let runtimeImports = [
+    'SkyuxConfigProvider',
+    'SkyuxConfig',
+    'SKYUX_CONFIG'
+  ];
+
+  let runtimeProviders = [`{
+    provide: SkyuxConfigProvider,
+    useValue: SKYUX_CONFIG
+  }`];
 
   if (skyPagesConfig.auth) {
-    authHttpImport = `import { SkyAuthHttp } from '${skyPagesConfig.runtimeAlias}';`;
-    authHttpProvider = `
-    ,{
+    runtimeImports.push(`SkyAuthHttp`);
+    runtimeProviders.push(`{
       provide: SkyAuthHttp,
       useClass: SkyAuthHttp,
       deps: [XHRBackend, RequestOptions]
-    }`;
+    }`);
   }
 
   let moduleSource =
-`export const SKY_PAGES: any = ${JSON.stringify(skyPagesConfig)};
-
+`
 ${bootstrap}import '${skyPagesConfig.skyPagesOutAlias}/src/main';
 
 import {
@@ -73,12 +79,10 @@ import { ActivatedRoute, RouterModule, Routes } from '@angular/router';
 import { Subscription } from 'rxjs/Subscription';
 import { SkyModule } from '${skyPagesConfig.skyuxPathAlias}/core';
 import { AppExtrasModule } from '${skyPagesConfig.skyPagesOutAlias}/src/app/app-extras.module';
-${authHttpImport}
-
-// Needed before component declarations since the provider is injected.
-export const SkyPagesProvider = new OpaqueToken('SKY_PAGES');
+import { ${runtimeImports.join(', ')} } from '${skyPagesConfig.runtimeAlias}';
 
 ${components.imports}
+
 ${routes.definitions}
 
 // Routes need to be defined after their corresponding components
@@ -86,7 +90,7 @@ const appRoutingProviders: any[] = [];
 const routes: Routes = ${routes.declarations};
 const routing = RouterModule.forRoot(routes);
 
-if (SKY_PAGES.command === 'build') {
+if (SKYUX_CONFIG.command === 'build') {
   enableProdMode();
 }
 
@@ -107,12 +111,7 @@ if (SKY_PAGES.command === 'build') {
     ${names}
   ],
   providers: [
-    appRoutingProviders,
-    {
-      provide: SkyPagesProvider,
-      useValue: SKY_PAGES
-    }
-    ${authHttpProvider}
+    ${runtimeProviders.join()}
   ]
 }) export class SkyPagesModule { }`;
 

--- a/lib/sky-pages-route-generator.js
+++ b/lib/sky-pages-route-generator.js
@@ -32,7 +32,7 @@ export class ${name} implements OnInit, OnDestroy {
   private sub: Subscription;
 ${paramDeclarations}
   constructor(
-    @Inject(SkyPagesProvider) public SKY_PAGES: any,
+    @Inject(SkyuxConfigProvider) public skyuxConfig: SkyuxConfig,
     private route: ActivatedRoute
   ) { }
 

--- a/loader/skyux-config-module/index.js
+++ b/loader/skyux-config-module/index.js
@@ -1,0 +1,10 @@
+/*jshint node: true*/
+'use strict';
+
+module.exports = function (source) {
+  return `
+${source}
+
+SKYUX_CONFIG = ${JSON.stringify(this.options.SKYUX_CONFIG)};
+`;
+};

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -1,2 +1,3 @@
 export * from './auth-http';
 export * from './bootstrapper';
+export * from './skyux-config';

--- a/runtime/skyux-config.ts
+++ b/runtime/skyux-config.ts
@@ -1,0 +1,19 @@
+import { OpaqueToken } from '@angular/core';
+import { SkyAppBootstrapConfig } from './bootstrap-config';
+
+export let SkyuxConfigProvider = new OpaqueToken('skyux.config');
+export interface SkyuxConfig {
+  app?: any;
+  appSettings?: any;
+  bootstrapConfig?: SkyAppBootstrapConfig;
+  command?: string;
+  compileMode?: string;
+  host?: any;
+  mode?: string;
+  name?: string;
+  publicRoutes?: any;
+}
+
+// Please note, SKYUX_CONFIG is added to this file at runtime
+// but the interface above should accurately reflect its contents.
+export let SKYUX_CONFIG: SkyuxConfig = {};

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  Inject,
   OnInit
 } from '@angular/core';
 
@@ -17,7 +18,7 @@ import {
 
 import { BBHelp } from '@blackbaud/help-client';
 
-import { SKY_PAGES } from './sky-pages.module';
+import { SkyuxConfigProvider, SkyuxConfig } from '@blackbaud/skyux-builder/runtime';
 
 require('style!@blackbaud/skyux/dist/css/sky.css');
 require('style!./app.component.scss');
@@ -27,7 +28,10 @@ require('style!./app.component.scss');
   templateUrl: './app.component.html'
 })
 export class AppComponent implements OnInit {
-  constructor(private router: Router) { }
+  constructor(
+    private router: Router,
+    @Inject(SkyuxConfigProvider) private skyuxConfig: SkyuxConfig
+  ) { }
 
   public ngOnInit() {
     // Without this code, navigating to a new route doesn't cause the window to be
@@ -42,7 +46,7 @@ export class AppComponent implements OnInit {
   }
 
   private initShellComponents() {
-    const bootstrapConfig = SKY_PAGES.bootstrapConfig;
+    const bootstrapConfig = this.skyuxConfig.bootstrapConfig;
 
     if (bootstrapConfig) {
       const omnibarBootstrapConfig = bootstrapConfig.omnibar;
@@ -55,8 +59,8 @@ export class AppComponent implements OnInit {
 
         const baseUrl =
           (
-            SKY_PAGES.host.url +
-            SKY_PAGES.app.base.substr(0, SKY_PAGES.app.base.length - 1)
+            this.skyuxConfig.host.url +
+            this.skyuxConfig.app.base.substr(0, this.skyuxConfig.app.base.length - 1)
           ).toLowerCase();
 
         const nav = new BBOmnibarNavigation();
@@ -71,11 +75,11 @@ export class AppComponent implements OnInit {
           }
         };
 
-        if (SKY_PAGES.command === 'serve') {
+        if (this.skyuxConfig.command === 'serve') {
           // Add any global routes to the omnibar as a convenience to the developer.
           const globalRoutes =
-            SKY_PAGES.publicRoutes &&
-            SKY_PAGES.publicRoutes.filter((value: any) => {
+            this.skyuxConfig.publicRoutes &&
+            this.skyuxConfig.publicRoutes.filter((value: any) => {
               return value.global;
             });
 

--- a/test/sky-pages-module-generator.spec.js
+++ b/test/sky-pages-module-generator.spec.js
@@ -104,10 +104,9 @@ describe('SKY UX Builder module generator', () => {
   });
 
   it('should only provide the SkyAuthHttp service if the app is configured to use auth', () => {
-    const expectedImport = `import { SkyAuthHttp } from 'sky-pages-internal/runtime';`;
+    const expectedImport = `import { (.*)SkyAuthHttp(.*) } from 'sky-pages-internal/runtime';`;
 
-    const expectedProvider = `
-    ,{
+    const expectedProvider = `{
       provide: SkyAuthHttp,
       useClass: SkyAuthHttp,
       deps: [XHRBackend, RequestOptions]
@@ -115,14 +114,14 @@ describe('SKY UX Builder module generator', () => {
 
     let source = generator.getSource({});
 
-    expect(source).not.toContain(expectedImport);
+    expect(source).not.toMatch(expectedImport);
     expect(source).not.toContain(expectedProvider);
 
     source = generator.getSource({
       auth: true
     });
 
-    expect(source).toContain(expectedImport);
+    expect(source).toMatch(expectedImport);
     expect(source).toContain(expectedProvider);
   });
 });


### PR DESCRIPTION
Initial pass at how consumers might interact with the config at runtime.  Updated the automated route definition to inject `skyuxConfig`, which means it's accessible in all `index.html` files as:

```
{{ skyuxConfig | json }}
```

An example component would look like:

```
import { Component, Inject } from '@angular/core';
import { SkyuxConfig, SkyuxConfigProvider } from '@blackbaud/skyux-builder/runtime';

@Component({
  selector: 'my-home'
})
export class HomeComponent {
  constructor(@Inject(SkyuxConfigProvider) private skyuxConfig: SkyuxConfig) {
    console.log(skyuxConfig);
  }
}

```