### PR TITLE
find .spec files from src.

### DIFF
--- a/config/webpack/test.webpack.config.js
+++ b/config/webpack/test.webpack.config.js
@@ -19,7 +19,7 @@ function getWebpackConfig(skyPagesConfig) {
   const aliasBuilder = require('./alias-builder');
 
   const ENV = process.env.ENV = process.env.NODE_ENV = 'test';
-  const srcPath = path.resolve(process.cwd(), 'src', 'app');
+  const srcPath = path.resolve(process.cwd(), 'src');
   const moduleLoader = outPath('loader', 'sky-pages-module');
 
   const resolves = [


### PR DESCRIPTION
Karma currently only detects and finds `.spec` files inside of `src/app`.  This change would allow Karma to look for and detect the all test specific files inside the `src` folder instead, allowing user created modules to follow the best practice pattern and test their modules to skyux standards.