### PR TITLE
Resolving error with resolving loader.

### DIFF
--- a/utils/sky-style-loader.js
+++ b/utils/sky-style-loader.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-require('style!@blackbaud/skyux/dist/css/sky.css');
+require('style-loader!@blackbaud/skyux/dist/css/sky.css');
 
 var FontFaceObserver = require('fontfaceobserver');
 


### PR DESCRIPTION
Webpack 2 requires loaders to use the `-loader` suffix. Without it, an error is thrown.  https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed