### PR TITLE
Fixed TypeScript in sourcemaps

### DIFF
--- a/config/webpack/common.webpack.config.js
+++ b/config/webpack/common.webpack.config.js
@@ -93,14 +93,6 @@ function getWebpackConfig(skyPagesConfig) {
           exclude: /node_modules/
         },
         {
-          enforce: 'post',
-          loader: outPath('loader', 'sky-processor', 'postload'),
-          exclude: [
-            /node_modules/,
-            /\.ts$/
-          ]
-        },
-        {
           test: /\.s?css$/,
           use: [
             'raw-loader',

--- a/config/webpack/common.webpack.config.js
+++ b/config/webpack/common.webpack.config.js
@@ -95,7 +95,10 @@ function getWebpackConfig(skyPagesConfig) {
         {
           enforce: 'post',
           loader: outPath('loader', 'sky-processor', 'postload'),
-          exclude: /node_modules/
+          exclude: [
+            /node_modules/,
+            /\.ts$/
+          ]
         },
         {
           test: /\.s?css$/,

--- a/config/webpack/test.webpack.config.js
+++ b/config/webpack/test.webpack.config.js
@@ -83,14 +83,6 @@ function getWebpackConfig(skyPagesConfig) {
           exclude: /node_modules/
         },
         {
-          enforce: 'post',
-          loader: outPath('loader', 'sky-processor', 'postload'),
-          exclude: [
-            /node_modules/,
-            /\.ts$/
-          ]
-        },
-        {
           test: /\.ts$/,
           use: [
             {

--- a/config/webpack/test.webpack.config.js
+++ b/config/webpack/test.webpack.config.js
@@ -85,7 +85,10 @@ function getWebpackConfig(skyPagesConfig) {
         {
           enforce: 'post',
           loader: outPath('loader', 'sky-processor', 'postload'),
-          exclude: /node_modules/
+          exclude: [
+            /node_modules/,
+            /\.ts$/
+          ]
         },
         {
           test: /\.ts$/,


### PR DESCRIPTION
- Removed `postload` from webpack loaders, until we have a use-case for it.
- Fixes [issue 642](https://github.com/blackbaud/skyux2/issues/642).