### PR TITLE
Lint errors abort the build

### DIFF
--- a/config/webpack/test.webpack.config.js
+++ b/config/webpack/test.webpack.config.js
@@ -69,7 +69,11 @@ function getWebpackConfig(skyPagesConfig) {
           enforce: 'pre',
           test: /\.ts$/,
           loader: 'tslint-loader',
-          exclude: excludes
+          exclude: excludes,
+          options: {
+            emitErrors: true,
+            failOnHint: true
+          }
         },
         {
           enforce: 'pre',


### PR DESCRIPTION
Addresses [issue #527](https://github.com/blackbaud/skyux2/issues/527)

- I created another pull request for the [SKY UX Template](https://github.com/blackbaud/skyux-template/pull/23) to fix some linting errors, otherwise new SPA's will fail on build.