### PR TITLE
Local omnibar nav and routes rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@angular/platform-browser": "2.4.8",
     "@angular/platform-browser-dynamic": "2.4.8",
     "@angular/router": "3.4.8",
-    "@blackbaud/auth-client": "1.3.2",
+    "@blackbaud/auth-client": "1.4.0",
     "@blackbaud/help-client": "1.0.1",
     "@ngtools/webpack": "1.2.14",
     "@types/jasmine": "2.5.40",

--- a/runtime/config.ts
+++ b/runtime/config.ts
@@ -62,7 +62,10 @@ export interface SkyuxConfig {
   mode?: string;
   name?: string;
   plugins?: string[];
-  publicRoutes?: any[];
+  routes?: {
+    public: any[],
+    referenced: any[]
+  };
   omnibar?: any;
 }
 


### PR DESCRIPTION
- Added support for specifying local navigation in skyuxconfig.json

- Refactored `publicRoutes` property to `routes` with `public` and `referenced` properties in preparation for publishing to the nav service