### PR TITLE
added a replace string to remove BOM from json file before parse

### DIFF
--- a/config/sky-pages/sky-pages.config.js
+++ b/config/sky-pages/sky-pages.config.js
@@ -19,7 +19,8 @@ function resolve(root, args) {
 }
 
 function readConfig(file) {
-  return JSON.parse(fs.readFileSync(file, 'utf8'));
+  let bomFreeFile = fs.readFileSync(file, 'utf8').replace(/^\uFEFF/, '');
+  return JSON.parse(bomFreeFile);
 }
 
 module.exports = {

--- a/config/sky-pages/sky-pages.config.js
+++ b/config/sky-pages/sky-pages.config.js
@@ -1,7 +1,7 @@
 /*jshint node: true*/
 'use strict';
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const merge = require('merge');
 const logger = require('winston');
@@ -19,8 +19,7 @@ function resolve(root, args) {
 }
 
 function readConfig(file) {
-  let bomFreeFile = fs.readFileSync(file, 'utf8').replace(/^\uFEFF/, '');
-  return JSON.parse(bomFreeFile);
+  return fs.readJsonSync(file, 'utf8');
 }
 
 module.exports = {

--- a/test/config-sky-pages.spec.js
+++ b/test/config-sky-pages.spec.js
@@ -1,7 +1,7 @@
 /*jshint jasmine: true, node: true */
 'use strict';
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const logger = require('winston');
 
 describe('config sky-pages', () => {
@@ -25,7 +25,7 @@ describe('config sky-pages', () => {
 
   it('should load the config files that exist in order', () => {
     const tempSpaReference = 'SPA_REFERENCE';
-    const readFileSync = fs.readFileSync;
+    const readFileSync = fs.readJsonSync;
     const existsSync = fs.existsSync;
 
     spyOn(logger, 'info');
@@ -46,7 +46,7 @@ describe('config sky-pages', () => {
       return existsSync(filename);
     });
 
-    spyOn(fs, 'readFileSync').and.callFake((filename, encoding) => {
+    spyOn(fs, 'readJsonSync').and.callFake((filename, encoding) => {
 
       const isSpaDirectory = filename.includes(tempSpaReference);
       const isDefaultConfig = filename.includes('skyuxconfig.json');
@@ -89,11 +89,11 @@ describe('config sky-pages', () => {
           config.w = 6; // Unique to this file
         }
 
-        return JSON.stringify(config);
+        return config;
       }
 
       // Pass through normal behavior
-      return readFileSync(filename, encoding);
+      return readJsonSync(filename, encoding);
     });
 
     const lib = require('../config/sky-pages/sky-pages.config');

--- a/test/host-utils.spec.js
+++ b/test/host-utils.spec.js
@@ -1,7 +1,7 @@
 /*jshint jasmine: true, node: true */
 'use strict';
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const mock = require('mock-require');
 
 describe('host-utils', () => {
@@ -65,12 +65,12 @@ describe('host-utils', () => {
 
   it('should add externals, trim slash from host, and read name from package.json', () => {
 
-    const readFileSync = fs.readFileSync;
-    spyOn(fs, 'readFileSync').and.callFake((filename, encoding) => {
+    const readJsonSync = fs.readJsonSync;
+    spyOn(fs, 'readJsonSync').and.callFake((filename, encoding) => {
       if (filename.indexOf('package.json') > -1) {
-        return JSON.stringify({
+        return {
           name: 'my-name'
-        });
+        };
       }
 
       return readFileSync(filename, encoding);


### PR DESCRIPTION
Currently if editing the skyuxconfig.json file in Visual Studio, it addes a Byte Order Mark to the file, which causes the json parse to explode.  

https://github.com/nodejs/node-v0.x-archive/issues/1918#issuecomment-2480359

This is a work around as readFileSync doesn't strip out BOM by default. 
Related to:
https://github.com/blackbaud/skyux2/issues/700 