### PR TITLE
Added --no-coverage flag to `skyux watch`

### DIFF
--- a/cli/test.js
+++ b/cli/test.js
@@ -5,15 +5,9 @@
  * Spawns the karam start command.
  * @name test
  */
-function test(command, argv) {
-
+function test(command, argv = {}) {
   const path = require('path');
   const spawn = require('cross-spawn');
-
-  let runCoverage = 'true';
-  if (argv && argv.coverage === false) {
-    runCoverage = 'false';
-  }
 
   const karmaConfigPath = path.resolve(
     __dirname,
@@ -27,10 +21,14 @@ function test(command, argv) {
     'start',
     karmaConfigPath,
     '--command',
-    command,
-    '--coverage',
-    runCoverage
+    command
   ];
+
+  if (argv.coverage === false) {
+    flags.push('--no-coverage');
+  } else {
+    flags.push('--coverage');
+  }
 
   const options = {
     stdio: 'inherit'

--- a/cli/test.js
+++ b/cli/test.js
@@ -5,7 +5,7 @@
  * Spawns the karam start command.
  * @name test
  */
-function test(command, argv = {}) {
+function test(command, argv) {
   const path = require('path');
   const spawn = require('cross-spawn');
 
@@ -24,7 +24,7 @@ function test(command, argv = {}) {
     command
   ];
 
-  if (argv.coverage === false) {
+  if (argv && argv.coverage === false) {
     flags.push('--no-coverage');
   } else {
     flags.push('--coverage');

--- a/cli/test.js
+++ b/cli/test.js
@@ -5,10 +5,15 @@
  * Spawns the karam start command.
  * @name test
  */
-function test(command) {
+function test(command, argv) {
 
   const path = require('path');
   const spawn = require('cross-spawn');
+
+  let runCoverage = 'true';
+  if (argv && argv.coverage === false) {
+    runCoverage = 'false';
+  }
 
   const karmaConfigPath = path.resolve(
     __dirname,
@@ -22,7 +27,9 @@ function test(command) {
     'start',
     karmaConfigPath,
     '--command',
-    command
+    command,
+    '--coverage',
+    runCoverage
   ];
 
   const options = {

--- a/config/karma/dev.karma.conf.js
+++ b/config/karma/dev.karma.conf.js
@@ -17,7 +17,7 @@ function getConfig(config) {
 
   const runtimePath = path.resolve(process.cwd(), 'runtime');
   const skyPagesConfig = skyPagesConfigUtil.getSkyPagesConfig('test');
-  let webpackConfig = testWebpackConfig.getWebpackConfig({}, skyPagesConfig);
+  let webpackConfig = testWebpackConfig.getWebpackConfig(skyPagesConfig);
 
   // Import shared karma config
   testKarmaConf(config);

--- a/config/karma/dev.karma.conf.js
+++ b/config/karma/dev.karma.conf.js
@@ -17,7 +17,7 @@ function getConfig(config) {
 
   const runtimePath = path.resolve(process.cwd(), 'runtime');
   const skyPagesConfig = skyPagesConfigUtil.getSkyPagesConfig('test');
-  let webpackConfig = testWebpackConfig.getWebpackConfig(skyPagesConfig);
+  let webpackConfig = testWebpackConfig.getWebpackConfig({}, skyPagesConfig);
 
   // Import shared karma config
   testKarmaConf(config);

--- a/config/karma/shared.karma.conf.js
+++ b/config/karma/shared.karma.conf.js
@@ -34,7 +34,7 @@ function getConfig(config) {
       '../../utils/spec-styles.js': ['webpack'],
       '../../utils/spec-bundle.js': ['coverage', 'webpack', 'sourcemap']
     },
-    webpack: testWebpackConfig.getWebpackConfig(argv, skyPagesConfig),
+    webpack: testWebpackConfig.getWebpackConfig(skyPagesConfig, argv),
     coverageReporter: {
       dir: path.join(process.cwd(), 'coverage'),
       reporters: [

--- a/config/karma/shared.karma.conf.js
+++ b/config/karma/shared.karma.conf.js
@@ -34,7 +34,7 @@ function getConfig(config) {
       '../../utils/spec-styles.js': ['webpack'],
       '../../utils/spec-bundle.js': ['coverage', 'webpack', 'sourcemap']
     },
-    webpack: testWebpackConfig.getWebpackConfig(skyPagesConfig),
+    webpack: testWebpackConfig.getWebpackConfig(argv, skyPagesConfig),
     coverageReporter: {
       dir: path.join(process.cwd(), 'coverage'),
       reporters: [

--- a/config/webpack/test.webpack.config.js
+++ b/config/webpack/test.webpack.config.js
@@ -1,7 +1,7 @@
 /*jslint node: true */
 'use strict';
 
-function getWebpackConfig(skyPagesConfig, argv = {}) {
+function getWebpackConfig(skyPagesConfig, argv) {
 
   function spaPath() {
     return skyPagesConfigUtil.spaPath.apply(skyPagesConfigUtil, arguments);
@@ -20,6 +20,7 @@ function getWebpackConfig(skyPagesConfig, argv = {}) {
   const skyPagesConfigUtil = require('../sky-pages/sky-pages.config');
   const aliasBuilder = require('./alias-builder');
 
+  const runCoverage = (!argv || argv.coverage !== false);
   skyPagesConfig.runtime.includeRouteModule = false;
 
   const ENV = process.env.ENV = process.env.NODE_ENV = 'test';
@@ -163,7 +164,7 @@ function getWebpackConfig(skyPagesConfig, argv = {}) {
     ]
   };
 
-  if (argv.coverage !== false) {
+  if (runCoverage) {
     config.module.rules.push({
       enforce: 'post',
       test: /\.(js|ts)$/,

--- a/config/webpack/test.webpack.config.js
+++ b/config/webpack/test.webpack.config.js
@@ -1,7 +1,7 @@
 /*jslint node: true */
 'use strict';
 
-function getWebpackConfig(argv, skyPagesConfig) {
+function getWebpackConfig(skyPagesConfig, argv = {}) {
 
   function spaPath() {
     return skyPagesConfigUtil.spaPath.apply(skyPagesConfigUtil, arguments);
@@ -163,7 +163,7 @@ function getWebpackConfig(argv, skyPagesConfig) {
     ]
   };
 
-  if (argv.coverage === 'true') {
+  if (argv.coverage !== false) {
     config.module.rules.push({
       enforce: 'post',
       test: /\.(js|ts)$/,

--- a/config/webpack/test.webpack.config.js
+++ b/config/webpack/test.webpack.config.js
@@ -1,7 +1,8 @@
 /*jslint node: true */
 'use strict';
 
-function getWebpackConfig(skyPagesConfig) {
+function getWebpackConfig(argv, skyPagesConfig) {
+
   function spaPath() {
     return skyPagesConfigUtil.spaPath.apply(skyPagesConfigUtil, arguments);
   }
@@ -38,7 +39,7 @@ function getWebpackConfig(skyPagesConfig) {
 
   let alias = aliasBuilder.buildAliasList(skyPagesConfig);
 
-  return {
+  let config = {
     devtool: 'inline-source-map',
 
     resolveLoader: {
@@ -119,30 +120,6 @@ function getWebpackConfig(skyPagesConfig) {
             'raw-loader',
             'sass-loader'
           ]
-        },
-        {
-          enforce: 'post',
-          test: /\.(js|ts)$/,
-          use: [
-            {
-              loader: 'istanbul-instrumenter-loader',
-              options: {
-                esModules: true
-              }
-            },
-            {
-              loader: 'source-map-inline-loader'
-            }
-          ],
-          include: srcPath,
-          exclude: [
-            /\.(e2e|spec)\.ts$/,
-            /node_modules/,
-            /index\.ts/,
-            /fixtures/,
-            /testing/,
-            /src(\\|\/)app(\\|\/)lib/
-          ]
         }
       ]
     },
@@ -185,6 +162,35 @@ function getWebpackConfig(skyPagesConfig) {
       processExitCode
     ]
   };
+
+  if (argv.coverage === 'true') {
+    config.module.rules.push({
+      enforce: 'post',
+      test: /\.(js|ts)$/,
+      use: [
+        {
+          loader: 'istanbul-instrumenter-loader',
+          options: {
+            esModules: true
+          }
+        },
+        {
+          loader: 'source-map-inline-loader'
+        }
+      ],
+      include: srcPath,
+      exclude: [
+        /\.(e2e|spec)\.ts$/,
+        /node_modules/,
+        /index\.ts/,
+        /fixtures/,
+        /testing/,
+        /src(\\|\/)app(\\|\/)lib/
+      ]
+    });
+  }
+
+  return config;
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = {
         break;
       case 'test':
       case 'watch':
-        require('./cli/test')(command);
+        require('./cli/test')(command, argv);
         break;
       case 'version':
         require('./cli/version')();

--- a/test/cli-test.spec.js
+++ b/test/cli-test.spec.js
@@ -22,7 +22,7 @@ describe('cli test', () => {
       };
     });
 
-    require('../cli/test')(cmd, {});
+    require('../cli/test')(cmd);
     expect(found).toEqual(true);
     mock.stop('cross-spawn');
 
@@ -45,7 +45,7 @@ describe('cli test', () => {
       };
     });
 
-    require('../cli/test')(cmd, {});
+    require('../cli/test')(cmd);
     expect(found).toEqual(true);
     mock.stop('cross-spawn');
 
@@ -65,7 +65,7 @@ describe('cli test', () => {
       };
     });
 
-    require('../cli/test')(cmd, {});
+    require('../cli/test')(cmd);
     expect(argv.command).toEqual(cmd);
     mock.stop('cross-spawn');
 

--- a/test/cli-test.spec.js
+++ b/test/cli-test.spec.js
@@ -22,7 +22,7 @@ describe('cli test', () => {
       };
     });
 
-    require('../cli/test')(cmd);
+    require('../cli/test')(cmd, {});
     expect(found).toEqual(true);
     mock.stop('cross-spawn');
 
@@ -45,7 +45,7 @@ describe('cli test', () => {
       };
     });
 
-    require('../cli/test')(cmd);
+    require('../cli/test')(cmd, {});
     expect(found).toEqual(true);
     mock.stop('cross-spawn');
 
@@ -65,10 +65,27 @@ describe('cli test', () => {
       };
     });
 
-    require('../cli/test')(cmd);
+    require('../cli/test')(cmd, {});
     expect(argv.command).toEqual(cmd);
     mock.stop('cross-spawn');
 
+  });
+
+  it('should pass the --no-coverage flag to karma', () => {
+    const cmd = 'CUSTOM_CMD';
+    let argv;
+
+    const minimist = require('minimist');
+    mock('cross-spawn', (node, flags) => {
+      argv = minimist(flags);
+      return {
+        on: () => {}
+      };
+    });
+
+    require('../cli/test')(cmd, { coverage: false });
+    expect(argv.coverage).toEqual('false');
+    mock.stop('cross-spawn');
   });
 
   it('should pass the exitCode', (done) => {
@@ -87,7 +104,7 @@ describe('cli test', () => {
       }
     }));
 
-    require('../cli/test')('test');
+    require('../cli/test')('test', {});
     mock.stop('cross-spawn');
 
   });

--- a/test/cli-test.spec.js
+++ b/test/cli-test.spec.js
@@ -119,7 +119,7 @@ describe('cli test', () => {
       }
     }));
 
-    require('../cli/test')('test', {});
+    require('../cli/test')('test');
     mock.stop('cross-spawn');
 
   });

--- a/test/cli-test.spec.js
+++ b/test/cli-test.spec.js
@@ -71,20 +71,35 @@ describe('cli test', () => {
 
   });
 
+  it('should pass the --coverage flag to karma by default', () => {
+    const cmd = 'CUSTOM_CMD';
+    let found = false;
+
+    mock('cross-spawn', (node, flags) => {
+      found = flags.includes('--coverage');
+      return {
+        on: () => {}
+      };
+    });
+
+    require('../cli/test')(cmd);
+    expect(found).toEqual(true);
+    mock.stop('cross-spawn');
+  });
+
   it('should pass the --no-coverage flag to karma', () => {
     const cmd = 'CUSTOM_CMD';
-    let argv;
+    let found = false;
 
-    const minimist = require('minimist');
     mock('cross-spawn', (node, flags) => {
-      argv = minimist(flags);
+      found = flags.includes('--no-coverage');
       return {
         on: () => {}
       };
     });
 
     require('../cli/test')(cmd, { coverage: false });
-    expect(argv.coverage).toEqual('false');
+    expect(found).toEqual(true);
     mock.stop('cross-spawn');
   });
 

--- a/test/config-webpack-test.spec.js
+++ b/test/config-webpack-test.spec.js
@@ -4,6 +4,21 @@
 const runtimeUtils = require('../utils/runtime-test-utils');
 
 describe('config webpack common', () => {
+  let argv;
+  let skyPagesConfig;
+
+  beforeEach(() => {
+    argv = {
+      coverage: 'true'
+    };
+    skyPagesConfig = {
+      skyux: {
+        mode: 'advanced'
+      },
+      runtime: runtimeUtils.getDefaultRuntime()
+    };
+  });
+
   it('should expose a getWebpackConfig method', () => {
     const lib = require('../config/webpack/test.webpack.config');
     expect(typeof lib.getWebpackConfig).toEqual('function');
@@ -11,12 +26,19 @@ describe('config webpack common', () => {
 
   it('should return a config object', () => {
     const lib = require('../config/webpack/test.webpack.config');
-    const config = lib.getWebpackConfig({
-      skyux: {
-        mode: 'advanced'
-      },
-      runtime: runtimeUtils.getDefaultRuntime()
-    });
+    const config = lib.getWebpackConfig(argv, skyPagesConfig);
     expect(config).toEqual(jasmine.any(Object));
+  });
+
+  it('should not run coverage if argv.coverage is false', () => {
+    argv.coverage = 'false';
+    const lib = require('../config/webpack/test.webpack.config');
+    const config = lib.getWebpackConfig(argv, skyPagesConfig);
+
+    let instrumentLoader = config.module.rules.filter(rule => {
+      return (rule.use && rule.use[0].loader === 'istanbul-instrumenter-loader');
+    })[0];
+
+    expect(instrumentLoader).not.toBeDefined();
   });
 });

--- a/test/config-webpack-test.spec.js
+++ b/test/config-webpack-test.spec.js
@@ -8,9 +8,7 @@ describe('config webpack common', () => {
   let skyPagesConfig;
 
   beforeEach(() => {
-    argv = {
-      coverage: 'true'
-    };
+    argv = {};
     skyPagesConfig = {
       skyux: {
         mode: 'advanced'
@@ -26,14 +24,25 @@ describe('config webpack common', () => {
 
   it('should return a config object', () => {
     const lib = require('../config/webpack/test.webpack.config');
-    const config = lib.getWebpackConfig(argv, skyPagesConfig);
+    const config = lib.getWebpackConfig(skyPagesConfig);
     expect(config).toEqual(jasmine.any(Object));
   });
 
-  it('should not run coverage if argv.coverage is false', () => {
-    argv.coverage = 'false';
+  it('should run coverage by default', () => {
     const lib = require('../config/webpack/test.webpack.config');
-    const config = lib.getWebpackConfig(argv, skyPagesConfig);
+    const config = lib.getWebpackConfig(skyPagesConfig);
+
+    let instrumentLoader = config.module.rules.filter(rule => {
+      return (rule.use && rule.use[0].loader === 'istanbul-instrumenter-loader');
+    })[0];
+
+    expect(instrumentLoader).toBeDefined();
+  });
+
+  it('should not run coverage if argv.coverage is false', () => {
+    argv.coverage = false;
+    const lib = require('../config/webpack/test.webpack.config');
+    const config = lib.getWebpackConfig(skyPagesConfig, argv);
 
     let instrumentLoader = config.module.rules.filter(rule => {
       return (rule.use && rule.use[0].loader === 'istanbul-instrumenter-loader');


### PR DESCRIPTION
**How to test:**
- Type `skyux watch --no-coverage` <-- instrument loader will not mangle the source files

Addresses [issue #643](https://github.com/blackbaud/skyux2/issues/643)