### PR TITLE
e2e tests fail build

### DIFF
--- a/cli/e2e.js
+++ b/cli/e2e.js
@@ -36,8 +36,8 @@ function getProtractorConfigPath() {
  * @name killServers
  */
 function killServers(exitCode) {
-
   logger.info('Cleaning up running servers');
+
   if (seleniumServer) {
     logger.info('Closing selenium server');
     seleniumServer.kill();
@@ -67,24 +67,15 @@ function killServers(exitCode) {
  * @name spawnProtractor
  */
 function spawnProtractor(chunks, port, skyPagesConfig) {
-
   logger.info('Running Protractor');
+
   const protractorPath = path.resolve(
+    __dirname,
+    '..',
     'node_modules',
     '.bin',
     'protractor'
   );
-
-  // Generate a trimmed-down version of skyPagesConfig to pass to host-utils.js
-  let trimmedConfig = {
-    skyux: {
-      host: {},
-      app: {}
-    }
-  };
-  trimmedConfig.skyux.name = skyPagesConfig.skyux.name;
-  trimmedConfig.skyux.host.url = skyPagesConfig.skyux.host.url;
-  trimmedConfig.skyux.app.externals = skyPagesConfig.skyux.app.externals;
 
   const protractor = spawn.spawn(
     protractorPath,
@@ -93,7 +84,7 @@ function spawnProtractor(chunks, port, skyPagesConfig) {
       `--baseUrl ${skyPagesConfig.skyux.host.url}`,
       `--params.localUrl=https://localhost:${port}`,
       `--params.chunks=${JSON.stringify(chunks)}`,
-      `--params.skyPagesConfig=${JSON.stringify(trimmedConfig)}`
+      `--params.skyPagesConfig=${JSON.stringify(skyPagesConfig)}`
     ],
     spawnOptions
   );
@@ -106,15 +97,22 @@ function spawnProtractor(chunks, port, skyPagesConfig) {
  * @name spawnSelenium
  */
 function spawnSelenium() {
-
   const config = require(getProtractorConfigPath()).config;
-  return new Promise(resolve => {
-    logger.info('Spawning Selenium');
 
-    // Assumes we're running selenium oursevles, so we should prep it
+  return new Promise((resolve, reject) => {
+    logger.info('Spawning selenium...');
+
+    // Assumes we're running selenium ourselves, so we should prep it
     if (config.seleniumAddress) {
+      logger.info('Installing Selenium...');
       selenium.install({ logger: logger.info }, () => {
+        logger.info('Selenium installed. Starting...');
         selenium.start((err, child) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+
           seleniumServer = child;
           logger.info('Selenium server is ready.');
           resolve();
@@ -124,11 +122,20 @@ function spawnSelenium() {
     // Otherwise we need to prep protractor's selenium
     } else {
       const webdriverManagerPath = path.resolve(
+        __dirname,
+        '..',
         'node_modules',
         '.bin',
         'webdriver-manager'
       );
-      spawn.sync(webdriverManagerPath, ['update'], spawnOptions);
+
+      let results = spawn.sync(webdriverManagerPath, ['update'], spawnOptions);
+
+      if (results.error) {
+        reject(results.error);
+        return;
+      }
+
       logger.info('Selenium server is ready.');
       resolve();
     }
@@ -139,24 +146,35 @@ function spawnSelenium() {
  * Spawns the httpServer
  */
 function spawnServer() {
-  return new Promise(resolve => {
-    logger.info('Requesting Open Port');
+  return new Promise((resolve, reject) => {
+    logger.info('Requesting open port...');
+
     httpServer = HttpServer.createServer({
       root: 'dist/',
       cors: true,
       https: {
         cert: path.resolve(__dirname, '../', 'ssl', 'server.crt'),
         key: path.resolve(__dirname, '../', 'ssl', 'server.key')
+      },
+      logFn: (req, res, err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
       }
     });
-    portfinder.getPortPromise().then(port => {
-      logger.info(`Open Port Found: ${port}`);
-      logger.info('Starting Web Server');
-      httpServer.listen(port, 'localhost', () => {
-        logger.info('Web Server Running');
-        resolve(port);
-      });
-    });
+
+    portfinder
+      .getPortPromise()
+      .then(port => {
+        logger.info(`Open port found: ${port}`);
+        logger.info('Starting web server...');
+        httpServer.listen(port, 'localhost', () => {
+          logger.info('Web server running.');
+          resolve(port);
+        });
+      })
+      .catch(reject);
   });
 }
 
@@ -164,12 +182,14 @@ function spawnServer() {
  * Spawns the build process.  Captures the config used.
  */
 function spawnBuild(argv, skyPagesConfig, webpack) {
-  return new Promise(resolve => {
-    logger.info('Running build');
-    build(argv, skyPagesConfig, webpack).then(stats => {
-      logger.info('Completed build');
-      resolve(stats.toJson().chunks);
-    });
+  return new Promise((resolve, reject) => {
+    logger.info('Running build...');
+    build(argv, skyPagesConfig, webpack)
+      .then(stats => {
+        logger.info('Build complete.');
+        resolve(stats.toJson().chunks);
+      })
+      .catch(reject);
   });
 }
 
@@ -182,17 +202,23 @@ function e2e(argv, skyPagesConfig, webpack) {
   start = new Date().getTime();
   process.on('SIGINT', killServers);
 
-  Promise.all([
-    spawnBuild(argv, skyPagesConfig, webpack),
-    spawnServer(),
-    spawnSelenium()
-  ]).then(values => {
-    spawnProtractor(
-      values[0],
-      values[1],
-      skyPagesConfig
-    );
-  });
+  Promise
+    .all([
+      spawnBuild(argv, skyPagesConfig, webpack),
+      spawnServer(),
+      spawnSelenium()
+    ])
+    .then(values => {
+      spawnProtractor(
+        values[0],
+        values[1],
+        skyPagesConfig
+      );
+    })
+    .catch(err => {
+      logger.warn(`ERROR [skyux e2e]: ${err.message}`);
+      killServers(1);
+    });
 }
 
 module.exports = e2e;

--- a/cli/e2e.js
+++ b/cli/e2e.js
@@ -77,6 +77,17 @@ function spawnProtractor(chunks, port, skyPagesConfig) {
     'protractor'
   );
 
+  // Generate a trimmed-down version of skyPagesConfig to pass to host-utils.js
+  let trimmedConfig = {
+    skyux: {
+      host: {},
+      app: {}
+    }
+  };
+  trimmedConfig.skyux.name = skyPagesConfig.skyux.name;
+  trimmedConfig.skyux.host.url = skyPagesConfig.skyux.host.url;
+  trimmedConfig.skyux.app.externals = skyPagesConfig.skyux.app.externals;
+
   const protractor = spawn.spawn(
     protractorPath,
     [
@@ -84,7 +95,7 @@ function spawnProtractor(chunks, port, skyPagesConfig) {
       `--baseUrl ${skyPagesConfig.skyux.host.url}`,
       `--params.localUrl=https://localhost:${port}`,
       `--params.chunks=${JSON.stringify(chunks)}`,
-      `--params.skyPagesConfig=${JSON.stringify(skyPagesConfig)}`
+      `--params.skyPagesConfig=${JSON.stringify(trimmedConfig)}`
     ],
     spawnOptions
   );


### PR DESCRIPTION
Addresses [issue #721](https://github.com/blackbaud/skyux2/issues/721).

Aside from running e2e, this branch tests for several failures, including `http-server`, `selenium`, `webdriver-manager`, and `protractor`.

- To test, purposefully break one of your e2e tests (skyux-template repo has a sample test)
- Run `skyux e2e && echo "hello"` <-- "hello" should never be printed to the console.