### PR TITLE
Allowing browser flag in serve

### DIFF
--- a/test/config-webpack-serve.spec.js
+++ b/test/config-webpack-serve.spec.js
@@ -132,10 +132,9 @@ describe('config webpack serve', () => {
       }
     });
 
+    const url = 'https://my-host-server.url/@blackbaud/skyux-builder/?local=true&_cfg=';
     expect(logger.info).toHaveBeenCalledTimes(2);
-    expect(openParamUrl).toContain(
-      'https://my-host-server.url/@blackbaud/skyux-builder/?local=true&_cfg='
-    );
+    expect(openParamUrl.indexOf(url)).toBe(0);
   });
 
   it('should log the host url and launch it when --launch host', () => {
@@ -157,8 +156,9 @@ describe('config webpack serve', () => {
       }
     });
 
+    const url = 'https://my-host-server.url';
     expect(logger.info).toHaveBeenCalledTimes(2);
-    expect(openParamUrl).toContain('https://my-host-server.url');
+    expect(openParamUrl.indexOf(url)).toBe(0);
   });
 
   it('should log the local url and launch it when --launch local', () => {
@@ -180,8 +180,9 @@ describe('config webpack serve', () => {
       }
     });
 
+    const url = 'https://localhost:1234';
     expect(logger.info).toHaveBeenCalledTimes(2);
-    expect(openParamUrl).toContain('https://localhost:1234');
+    expect(openParamUrl.indexOf(url)).toBe(0);
   });
 
   it('should log a done message and not launch it when --launch none', () => {
@@ -295,10 +296,11 @@ describe('config webpack serve', () => {
               const urlParsed = urlLibrary.parse(openParamUrl, true);
               const configString = new Buffer.from(urlParsed.query._cfg, 'base64').toString();
               const configObject = JSON.parse(configString);
+              const url = 'https://localhost:1234';
 
               expect(urlParsed.query._cfg).toBeDefined();
               expect(configObject.externals).toEqual(skyuxConfig.skyux.app.externals);
-              expect(configObject.localUrl).toContain('https://localhost:1234');
+              expect(configObject.localUrl.indexOf(url)).toBe(0);
               expect(configObject.scripts).toEqual([
                 { name: 'a.js' },
                 { name: 'b.js' }

--- a/test/config-webpack-serve.spec.js
+++ b/test/config-webpack-serve.spec.js
@@ -354,7 +354,7 @@ describe('config webpack serve', () => {
     argv.browser = 'edge';
     bindToDone();
     expect(openParamBrowser).not.toBeDefined();
-    expect(openParamUrl).toContain('microsoft-edge:');
+    expect(openParamUrl.indexOf('microsoft-edge')).toBe(0);
   });
 
 });


### PR DESCRIPTION
Tested in OSX and Windows against `chrome`, `firefox`, `safari`, `iexplore`, and `edge`.  

A few notes:
- `edge` has to be a hard-coded use-case since they only expose a protocol `microsoft-edge:` instead of an executable.
- This only updates the `skyux serve` command.  Support could also be added for the `skyux test`, `skyux watch`, and `skyux e2e` commands.

Fixes https://github.com/blackbaud/skyux2/issues/402