### PR TITLE
Add support for route guards

### DIFF
--- a/e2e/shared/common.js
+++ b/e2e/shared/common.js
@@ -114,7 +114,7 @@ function prepareBuild(config) {
     resetConfig();
 
     // Create our server
-    httpServer = HttpServer.createServer({ root: tmp });
+    httpServer = HttpServer.createServer({ root: tmp, cache: 0 });
 
     return new Promise((resolve, reject) => {
       portfinder.getPortPromise()
@@ -193,6 +193,43 @@ function writeConfigServe(port) {
   });
 }
 
+/**
+ * Write a file into the src/app folder -- Used for injecting files prior to build
+ * that we don't want to include in the skyux-template but need to test
+ */
+function writeAppFile(filePath, content) {
+  return new Promise((resolve, reject) => {
+    const resolvedFilePath = path.join(path.resolve(tmp), 'src', 'app', filePath);
+    fs.writeFile(resolvedFilePath, content, (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+/**
+ * Remove file from the src/app folder -- Used for cleaning up after we've injected
+ * files for a specific test or group of tests
+ */
+function removeAppFile(filePath) {
+  return new Promise((resolve, reject) => {
+    const resolvedFilePath = path.join(path.resolve(tmp), 'src', 'app', filePath);
+
+    fs.unlink(resolvedFilePath, (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
 module.exports = {
   afterAll: afterAll,
   catchReject: catchReject,
@@ -203,5 +240,7 @@ module.exports = {
   getExitCode: getExitCode,
   prepareBuild: prepareBuild,
   prepareServe: prepareServe,
-  tmp: tmp
+  tmp: tmp,
+  writeAppFile: writeAppFile,
+  removeAppFile: removeAppFile
 };

--- a/e2e/shared/tests.js
+++ b/e2e/shared/tests.js
@@ -46,5 +46,12 @@ module.exports = {
     nav.get(1).click();
     expect(element(by.tagName('h1')).getText()).toBe('About our Team');
     done();
+  },
+
+  respectGuardCanActivate: (done) => {
+    const nav = $$('.sky-navbar-item a');
+    nav.get(1).click();
+    expect(element(by.tagName('h1')).getText()).toBe('SKY UX Template');
+    done();
   }
 };

--- a/e2e/skyux-build-aot.e2e-spec.js
+++ b/e2e/skyux-build-aot.e2e-spec.js
@@ -3,28 +3,55 @@
 const common = require('./shared/common');
 const tests = require('./shared/tests');
 
-describe('skyux build aot', () => {
+function prepareBuild() {
+  const opts = { mode: 'easy', name: 'dist', compileMode: 'aot' };
+  return common.prepareBuild(opts)
+    .catch(console.error);
+}
 
-  beforeAll((done) => {
-    const opts = { mode: 'easy', name: 'dist', compileMode: 'aot' };
-    common.prepareBuild(opts)
-      .then(done)
-      .catch(err => {
-        console.log(err);
-        done();
-      });
+describe('skyux build aot', () => {
+  describe('w/base template', () => {
+    beforeAll((done) => prepareBuild().then(done));
+
+    it('should have exitCode 0', tests.verifyExitCode);
+
+    it('should generate expected static files', tests.verifyFiles);
+
+    it('should render the home components', tests.renderHomeComponent);
+
+    it('should render shared nav component', tests.renderSharedNavComponent);
+
+    it('should follow routerLink and render about component', tests.followRouterLinkRenderAbout);
+
+    afterAll(common.afterAll);
   });
 
-  afterAll(common.afterAll);
+  describe('w/guard', () => {
+    beforeAll((done) => {
+      const guard = `
+import { Injectable } from '@angular/core';
 
-  it('should have exitCode 0', tests.verifyExitCode);
+@Injectable()
+export class AboutGuard {
+  canActivate(next: any, state: any) {
+    return false;
+  }
+}
+`;
 
-  it('should generate expected static files', tests.verifyFiles);
+      common.writeAppFile('about/index.guard.ts', guard)
+        .then(() => prepareBuild())
+        .then(done)
+        .catch(console.error);
+    });
 
-  it('should render the home components', tests.renderHomeComponent);
+    it('should not follow routerLink when guard returns false', tests.respectGuardCanActivate);
 
-  it('should render shared nav component', tests.renderSharedNavComponent);
-
-  it('should follow routerLink and render about component', tests.followRouterLinkRenderAbout);
-
+    afterAll((done) => {
+      common.removeAppFile('about/index.guard.ts')
+        .then(() => common.afterAll())
+        .then(done)
+        .catch(console.error);
+    });
+  });
 });

--- a/e2e/skyux-build-jit.e2e-spec.js
+++ b/e2e/skyux-build-jit.e2e-spec.js
@@ -3,28 +3,55 @@
 const common = require('./shared/common');
 const tests = require('./shared/tests');
 
-describe('skyux build jit', () => {
+function prepareBuild() {
+  const opts = { mode: 'easy', name: 'dist', compileMode: 'jit' };
+  return common.prepareBuild(opts)
+    .catch(err => console.error);
+}
 
-  beforeAll((done) => {
-    const opts = { mode: 'easy', name: 'dist', compileMode: 'jit' };
-    common.prepareBuild(opts)
-      .then(done)
-      .catch(err => {
-        console.log(err);
-        done();
-      });
+describe('skyux build jit', () => {
+  describe('w/base template', () => {
+    beforeAll((done) => prepareBuild().then(done));
+
+    it('should have exitCode 0', tests.verifyExitCode);
+
+    it('should generate expected static files', tests.verifyFiles);
+
+    it('should render the home components', tests.renderHomeComponent);
+
+    it('should render shared nav component', tests.renderSharedNavComponent);
+
+    it('should follow routerLink and render about component', tests.followRouterLinkRenderAbout);
+
+    afterAll(common.afterAll);
   });
 
-  afterAll(common.afterAll);
+  describe('w/guard', () => {
+    beforeAll((done) => {
+      const guard = `
+import { Injectable } from '@angular/core';
 
-  it('should have exitCode 0', tests.verifyExitCode);
+@Injectable()
+export class AboutGuard {
+  canActivate(next: any, state: any) {
+    return false;
+  }
+}
+`;
 
-  it('should generate expected static files', tests.verifyFiles);
+      common.writeAppFile('about/index.guard.ts', guard)
+        .then(() => prepareBuild())
+        .then(done)
+        .catch(console.error);
+    });
 
-  it('should render the home components', tests.renderHomeComponent);
+    it('should not follow routerLink when guard returns false', tests.respectGuardCanActivate);
 
-  it('should render shared nav component', tests.renderSharedNavComponent);
-
-  it('should follow routerLink and render about component', tests.followRouterLinkRenderAbout);
-
+    afterAll((done) => {
+      common.removeAppFile('about/index.guard.ts')
+        .then(() => common.afterAll())
+        .then(done)
+        .catch(console.error);
+    });
+  });
 });

--- a/lib/sky-pages-module-generator.js
+++ b/lib/sky-pages-module-generator.js
@@ -124,6 +124,7 @@ import {
   AppExtrasModule
 } from '${skyAppConfig.runtime.skyPagesOutAlias}/src/app/app-extras.module';
 import { ${runtimeImports.join(', ')} } from '${skyAppConfig.runtime.runtimeAlias}';
+${routes.imports.join('\n')}
 
 export function SkyAppConfigFactory(windowRef: SkyAppWindowRef): any {
   const config: any = ${skyAppConfigAsString};
@@ -141,7 +142,7 @@ ${components.imports}
 ${routes.definitions}
 
 // Routes need to be defined after their corresponding components
-const appRoutingProviders: any[] = ${routes.providers};
+const appRoutingProviders: any[] = [${routes.providers}];
 const routes: Routes = ${routes.declarations};
 const routing = RouterModule.forRoot(routes);
 

--- a/lib/sky-pages-module-generator.js
+++ b/lib/sky-pages-module-generator.js
@@ -141,7 +141,7 @@ ${components.imports}
 ${routes.definitions}
 
 // Routes need to be defined after their corresponding components
-const appRoutingProviders: any[] = [];
+const appRoutingProviders: any[] = ${routes.providers};
 const routes: Routes = ${routes.declarations};
 const routing = RouterModule.forRoot(routes);
 

--- a/lib/sky-pages-route-generator.js
+++ b/lib/sky-pages-route-generator.js
@@ -3,6 +3,7 @@
 
 const glob = require('glob');
 const path = require('path');
+const fs = require('fs');
 
 function indent(count) {
   return '  '.repeat(count);
@@ -53,6 +54,11 @@ function parseFileIntoEntity(skyAppConfig, file, index) {
 
   let routePath = [];
   let routeParams = [];
+  let parsedPath = path.parse(file);
+
+  // Make no assumptions on extension used to create route, just remove
+  // it and append .guard.ts (ex: index.html -> index.guard.ts)
+  let guardPath = path.join(parsedPath.dir, `${parsedPath.name}.guard.ts`);
 
   // Removes srcPath + filename
   // glob always uses '/' for path separator!
@@ -85,7 +91,8 @@ function parseFileIntoEntity(skyAppConfig, file, index) {
     componentName: componentName,
     componentDefinition: componentDefinition,
     routePath: routePath.join('/'),
-    routeParams: routeParams
+    routeParams: routeParams,
+    guardPath: fs.existsSync(guardPath) ? guardPath : undefined
   };
 }
 
@@ -114,9 +121,28 @@ function generateDefinitions(routes) {
 function generateDeclarations(routes) {
   const p = indent(1);
   const declarations = routes
-    .map(r => `${p}{ path: '${r.routePath}', component: ${r.componentName} }`)
+    .map(r => {
+      let guard = r.guardPath ? `require('${r.guardPath}').default` : '';
+      let declaration =
+`${p}{
+  path: '${r.routePath}',
+  component: ${r.componentName},
+  canActivate: [${guard}],
+  canDeactivate: [${guard}]
+}`;
+
+      return declaration;
+    })
     .join(',\n');
   return `[\n${declarations}\n]`;
+}
+
+function generateProviders(routes) {
+  const providers = routes
+    .map(r => r.guardPath ? `require('${r.guardPath}').default` : undefined)
+    .filter(p => p);
+
+  return `[\n${providers}\n]`;
 }
 
 function generateNames(routes) {
@@ -137,6 +163,7 @@ function getRoutes(skyAppConfig) {
   return {
     declarations: generateDeclarations(routes),
     definitions: generateDefinitions(routes),
+    providers: generateProviders(routes),
     names: generateNames(routes),
     routesForConfig: getRoutesForConfig(routes)
   };

--- a/lib/sky-pages-route-generator.js
+++ b/lib/sky-pages-route-generator.js
@@ -59,12 +59,9 @@ function parseFileIntoEntity(skyAppConfig, file, index) {
   // Make no assumptions on extension used to create route, just remove
   // it and append .guard.ts (ex: index.html -> index.guard.ts)
   let guardPath = path.join(parsedPath.dir, `${parsedPath.name}.guard.ts`);
-  let guardName;
-
+  let guard;
   if (fs.existsSync(guardPath)) {
-    guardName = extractGuardName(guardPath);
-  } else {
-    guardPath = undefined;
+    guard = extractGuard(guardPath);
   }
 
   // Removes srcPath + filename
@@ -99,8 +96,7 @@ function parseFileIntoEntity(skyAppConfig, file, index) {
     componentDefinition: componentDefinition,
     routePath: routePath.join('/'),
     routeParams: routeParams,
-    guardPath: guardPath,
-    guardName: guardName
+    guard: guard
   };
 }
 
@@ -130,7 +126,7 @@ function generateDeclarations(routes) {
   const p = indent(1);
   const declarations = routes
     .map(r => {
-      let guard = r.guardPath && r.guardName ? `require('${r.guardPath}').${r.guardName}` : '';
+      let guard = r.guard ? r.guard.name : '';
       let declaration =
 `${p}{
   path: '${r.routePath}',
@@ -145,12 +141,16 @@ function generateDeclarations(routes) {
   return `[\n${declarations}\n]`;
 }
 
-function generateProviders(routes) {
-  const providers = routes
-    .map(r => r.guardPath ? `require('${r.guardPath}').${r.guardName}` : undefined)
-    .filter(p => p);
+function generateRuntimeImports(routes) {
+  return routes
+    .filter(r => r.guard)
+    .map(r => `import { ${r.guard.name} } from '${r.guard.path.replace(/\.ts$/, '')}';`);
+}
 
-  return `[\n${providers}\n]`;
+function generateProviders(routes) {
+  return routes
+    .filter(r => r.guard)
+    .map(r => r.guard.name);
 }
 
 function generateNames(routes) {
@@ -171,14 +171,15 @@ function getRoutes(skyAppConfig) {
   return {
     declarations: generateDeclarations(routes),
     definitions: generateDefinitions(routes),
+    imports: generateRuntimeImports(routes),
     providers: generateProviders(routes),
     names: generateNames(routes),
     routesForConfig: getRoutesForConfig(routes)
   };
 }
 
-function extractGuardName(file) {
-  const matchRegexp = /@Injectable\s*\(\s*\)\s*export\s*(default)*\s*class\s(\w+)/g;
+function extractGuard(file) {
+  const matchRegexp = /@Injectable\s*\(\s*\)\s*export\s*class\s(\w+)/g;
   const content = fs.readFileSync(file, { encoding: 'utf8' });
 
   let result;
@@ -188,8 +189,7 @@ function extractGuardName(file) {
       throw new Error(`As a best practice, only export one guard per file in ${file}`);
     }
 
-    // If its a default export, use that value instead of guard component name
-    result = match[1] || match[2];
+    result = { path: file, name: match[1] };
   }
 
   return result;

--- a/lib/sky-pages-route-generator.js
+++ b/lib/sky-pages-route-generator.js
@@ -189,7 +189,7 @@ function extractGuard(file) {
       throw new Error(`As a best practice, only export one guard per file in ${file}`);
     }
 
-    result = { path: file, name: match[1] };
+    result = { path: path.resolve(file), name: match[1] };
   }
 
   return result;

--- a/lib/sky-pages-route-generator.js
+++ b/lib/sky-pages-route-generator.js
@@ -59,6 +59,13 @@ function parseFileIntoEntity(skyAppConfig, file, index) {
   // Make no assumptions on extension used to create route, just remove
   // it and append .guard.ts (ex: index.html -> index.guard.ts)
   let guardPath = path.join(parsedPath.dir, `${parsedPath.name}.guard.ts`);
+  let guardName;
+
+  if (fs.existsSync(guardPath)) {
+    guardName = extractGuardName(guardPath);
+  } else {
+    guardPath = undefined;
+  }
 
   // Removes srcPath + filename
   // glob always uses '/' for path separator!
@@ -92,7 +99,8 @@ function parseFileIntoEntity(skyAppConfig, file, index) {
     componentDefinition: componentDefinition,
     routePath: routePath.join('/'),
     routeParams: routeParams,
-    guardPath: fs.existsSync(guardPath) ? guardPath : undefined
+    guardPath: guardPath,
+    guardName: guardName
   };
 }
 
@@ -122,7 +130,7 @@ function generateDeclarations(routes) {
   const p = indent(1);
   const declarations = routes
     .map(r => {
-      let guard = r.guardPath ? `require('${r.guardPath}').default` : '';
+      let guard = r.guardPath && r.guardName ? `require('${r.guardPath}').${r.guardName}` : '';
       let declaration =
 `${p}{
   path: '${r.routePath}',
@@ -139,7 +147,7 @@ function generateDeclarations(routes) {
 
 function generateProviders(routes) {
   const providers = routes
-    .map(r => r.guardPath ? `require('${r.guardPath}').default` : undefined)
+    .map(r => r.guardPath ? `require('${r.guardPath}').${r.guardName}` : undefined)
     .filter(p => p);
 
   return `[\n${providers}\n]`;
@@ -167,6 +175,24 @@ function getRoutes(skyAppConfig) {
     names: generateNames(routes),
     routesForConfig: getRoutesForConfig(routes)
   };
+}
+
+function extractGuardName(file) {
+  const matchRegexp = /@Injectable\s*\(\s*\)\s*export\s*(default)*\s*class\s(\w+)/g;
+  const content = fs.readFileSync(file, { encoding: 'utf8' });
+
+  let result;
+  let match;
+  while ((match = matchRegexp.exec(content))) {
+    if (result !== undefined) {
+      throw new Error(`As a best practice, only export one guard per file in ${file}`);
+    }
+
+    // If its a default export, use that value instead of guard component name
+    result = match[1] || match[2];
+  }
+
+  return result;
 }
 
 module.exports = {

--- a/test/sky-pages-route-generator.spec.js
+++ b/test/sky-pages-route-generator.spec.js
@@ -104,4 +104,31 @@ describe('SKY UX Builder route generator', () => {
     expect(suppliedPattern).toEqual('my-custom-src/my-custom-pattern');
   });
 
+  it('should support guards with custom routesPattern', () => {
+    let suppliedPattern;
+    spyOn(glob, 'sync').and.callFake((p) => {
+      suppliedPattern = p;
+      return ['my-custom-src/my-custom-route/index.html'];
+    });
+    spyOn(fs, 'existsSync').and.returnValue(true);
+
+    let routes = generator.getRoutes({
+      runtime: {
+        srcPath: 'my-custom-src/',
+        routesPattern: 'my-custom-pattern',
+      }
+    });
+
+    expect(routes.declarations).toContain(
+      `canActivate: [require(\'my-custom-src/my-custom-route/index.guard.ts\').default]`
+    );
+
+    expect(routes.declarations).toContain(
+      `canDeactivate: [require(\'my-custom-src/my-custom-route/index.guard.ts\').default]`
+    );
+
+    expect(routes.providers).toContain(
+      `require(\'my-custom-src/my-custom-route/index.guard.ts\').default`
+    );
+  });
 });

--- a/test/sky-pages-route-generator.spec.js
+++ b/test/sky-pages-route-generator.spec.js
@@ -117,40 +117,15 @@ describe('SKY UX Builder route generator', () => {
     });
 
     expect(routes.declarations).toContain(
-      `canActivate: [require(\'my-custom-src/my-custom-route/index.guard.ts\').Guard]`
+      `canActivate: [Guard]`
     );
 
     expect(routes.declarations).toContain(
-      `canDeactivate: [require(\'my-custom-src/my-custom-route/index.guard.ts\').Guard]`
+      `canDeactivate: [Guard]`
     );
 
     expect(routes.providers).toContain(
-      `require(\'my-custom-src/my-custom-route/index.guard.ts\').Guard`
-    );
-  });
-
-  it('should support default export guards', () => {
-    spyOn(glob, 'sync').and.callFake(() => ['my-custom-src/my-custom-route/index.html']);
-    spyOn(fs, 'readFileSync').and.returnValue('@Injectable() export default class Guard {}');
-    spyOn(fs, 'existsSync').and.returnValue(true);
-
-    let routes = generator.getRoutes({
-      runtime: {
-        srcPath: 'my-custom-src/',
-        routesPattern: 'my-custom-pattern',
-      }
-    });
-
-    expect(routes.declarations).toContain(
-      `canActivate: [require(\'my-custom-src/my-custom-route/index.guard.ts\').default]`
-    );
-
-    expect(routes.declarations).toContain(
-      `canDeactivate: [require(\'my-custom-src/my-custom-route/index.guard.ts\').default]`
-    );
-
-    expect(routes.providers).toContain(
-      `require(\'my-custom-src/my-custom-route/index.guard.ts\').default`
+      `Guard`
     );
   });
 
@@ -158,7 +133,7 @@ describe('SKY UX Builder route generator', () => {
     spyOn(glob, 'sync').and.callFake(() => ['my-custom-src/my-custom-route/index.html']);
     spyOn(fs, 'existsSync').and.returnValue(true);
     spyOn(fs, 'readFileSync').and.returnValue(`
-      @Injectable() export default class Guard {}
+      @Injectable() export class Guard {}
       @Injectable() export class Guard2 {}
     `);
 


### PR DESCRIPTION
Adds support for canActivate/canDeactivate route guards as requested in blackbaud/skyux2#423.

I want to look at refactoring the way route generation works to use childRoutes and all for canActivateChild as well but this is a solid first step to unblock some consumers.