### PR TITLE
Child route support, root guard support

### DIFF
--- a/e2e/shared/common.js
+++ b/e2e/shared/common.js
@@ -212,6 +212,34 @@ function writeAppFile(filePath, content) {
 }
 
 /**
+ * Verify directory exists in src/app folder
+ */
+function verifyAppFolder(folderPath) {
+  const resolvedFolderPath = path.join(path.resolve(tmp), 'src', 'app', folderPath);
+  return new Promise((resolve, reject) => {
+    if (!fs.existsSync(resolvedFolderPath)) {
+      fs.mkdirSync(resolvedFolderPath);
+    }
+
+    resolve();
+  });
+}
+
+/**
+ * Verify directory exists in src/app folder
+ */
+function removeAppFolder(folderPath) {
+  const resolvedFolderPath = path.join(path.resolve(tmp), 'src', 'app', folderPath);
+  return new Promise((resolve, reject) => {
+    if (fs.existsSync(resolvedFolderPath)) {
+      fs.rmdirSync(resolvedFolderPath);
+    }
+
+    resolve();
+  });
+}
+
+/**
  * Remove file from the src/app folder -- Used for cleaning up after we've injected
  * files for a specific test or group of tests
  */
@@ -242,5 +270,7 @@ module.exports = {
   prepareServe: prepareServe,
   tmp: tmp,
   writeAppFile: writeAppFile,
-  removeAppFile: removeAppFile
+  removeAppFile: removeAppFile,
+  verifyAppFolder: verifyAppFolder,
+  removeAppFolder: removeAppFolder
 };

--- a/e2e/shared/tests.js
+++ b/e2e/shared/tests.js
@@ -1,5 +1,5 @@
 /*jshint jasmine: true, node: true */
-/*global element, by, $$*/
+/*global element, by, $$, protractor, browser*/
 'use strict';
 
 const fs = require('fs');
@@ -52,6 +52,40 @@ module.exports = {
     const nav = $$('.sky-navbar-item a');
     nav.get(1).click();
     expect(element(by.tagName('h1')).getText()).toBe('SKY UX Template');
+
+    const aboutComponent = $$('my-about')[0];
+    expect(aboutComponent).toBe(undefined);
+
+    done();
+  },
+
+  respectRootGuard: (done) => {
+    // if the home component isn't there, the outlet was not
+    // allowed to activate due to the Guard!
+    const homeComponent = $$('my-home')[0];
+    expect(homeComponent).toBe(undefined);
+    done();
+  },
+
+  verifyChildRoute: (done) => {
+    $$('#test').get(0).click();
+    expect($$('h1').get(0).getText()).toBe('Hi');
+    done();
+  },
+
+  verifyNestedChildRoute: (done) => {
+    $$('#child').get(0).click();
+
+    expect($$('h1').get(0).getText()).toBe('Hi');
+    expect($$('#text').get(0).getText()).toBe('Child');
+    done();
+  },
+
+  verifyNestedTopRoute: (done) => {
+    $$('#top').get(0).click();
+
+    expect($$('h1')[0]).toBe(undefined);
+    expect($$('#text').get(0).getText()).toBe('Top');
     done();
   }
 };

--- a/e2e/skyux-build-aot.e2e-spec.js
+++ b/e2e/skyux-build-aot.e2e-spec.js
@@ -54,4 +54,73 @@ export class AboutGuard {
         .catch(console.error);
     });
   });
+
+  describe('w/root level guard', () => {
+    beforeAll((done) => {
+      const guard = `
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class RootGuard {
+  canActivateChild(next: any, state: any) {
+    return false;
+  }
+}
+`;
+
+      common.writeAppFile('index.guard.ts', guard)
+        .then(() => prepareBuild())
+        .then(done)
+        .catch(console.error);
+    });
+
+    it('should respect root guard', tests.respectRootGuard);
+
+    afterAll((done) => {
+      common.removeAppFile('index.guard.ts')
+        .then(() => common.afterAll())
+        .then(done)
+        .catch(console.error);
+    });
+  });
+
+  describe('w/child routes', () => {
+    beforeAll((done) => {
+      common.verifyAppFolder('test')
+        .then(() => common.writeAppFile('index.html', '<a id="test" routerLink="/test">Test</a>'))
+        .then(() => common.writeAppFile(
+          'test/index.html',
+          '<h1>Hi</h1>' +
+          '<a id="child" routerLink="/test/child">Child</a>' +
+          '<a id="top" routerLink="/test/child/top">Top</a>' +
+          '<router-outlet></router-outlet>')
+        )
+        .then(() => common.verifyAppFolder('test/#child'))
+        .then(() => common.writeAppFile('test/#child/index.html', '<div id="text">Child</div>'))
+        .then(() => common.verifyAppFolder('test/#child/top'))
+        .then(() => common.writeAppFile('test/#child/top/index.html', '<div id="text">Top</div>'))
+        .then(() => prepareBuild())
+        .then(done)
+        .catch(console.error);
+    });
+
+    it('should have working child route', tests.verifyChildRoute);
+
+    it('should have working nested child route', tests.verifyNestedChildRoute);
+
+    it('should have working top level route inside child route folder', tests.verifyNestedTopRoute);
+
+    afterAll((done) => {
+      common.removeAppFile('test/#child/top/index.html')
+        .then(() => common.writeAppFile('index.html', '<my-home></my-home>'))
+        .then(() => common.removeAppFile('test/#child/index.html'))
+        .then(() => common.removeAppFile('test/index.html'))
+        .then(() => common.removeAppFolder('test/#child/top'))
+        .then(() => common.removeAppFolder('test/#child'))
+        .then(() => common.removeAppFolder('test'))
+        .then(() => common.afterAll())
+        .then(done)
+        .catch(console.error);
+    });
+  });
 });

--- a/e2e/skyux-build-jit.e2e-spec.js
+++ b/e2e/skyux-build-jit.e2e-spec.js
@@ -54,4 +54,73 @@ export class AboutGuard {
         .catch(console.error);
     });
   });
+
+  describe('w/root level guard', () => {
+    beforeAll((done) => {
+      const guard = `
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class RootGuard {
+  canActivateChild(next: any, state: any) {
+    return false;
+  }
+}
+`;
+
+      common.writeAppFile('index.guard.ts', guard)
+        .then(() => prepareBuild())
+        .then(done)
+        .catch(console.error);
+    });
+
+    it('should respect root guard', tests.respectRootGuard);
+
+    afterAll((done) => {
+      common.removeAppFile('index.guard.ts')
+        .then(() => common.afterAll())
+        .then(done)
+        .catch(console.error);
+    });
+  });
+
+  describe('w/child routes', () => {
+    beforeAll((done) => {
+      common.verifyAppFolder('test')
+        .then(() => common.writeAppFile('index.html', '<a id="test" routerLink="/test">Test</a>'))
+        .then(() => common.writeAppFile(
+          'test/index.html',
+          '<h1>Hi</h1>' +
+          '<a id="child" routerLink="/test/child">Child</a>' +
+          '<a id="top" routerLink="/test/child/top">Top</a>' +
+          '<router-outlet></router-outlet>')
+        )
+        .then(() => common.verifyAppFolder('test/#child'))
+        .then(() => common.writeAppFile('test/#child/index.html', '<div id="text">Child</div>'))
+        .then(() => common.verifyAppFolder('test/#child/top'))
+        .then(() => common.writeAppFile('test/#child/top/index.html', '<div id="text">Top</div>'))
+        .then(() => prepareBuild())
+        .then(done)
+        .catch(console.error);
+    });
+
+    it('should have working child route', tests.verifyChildRoute);
+
+    it('should have working nested child route', tests.verifyNestedChildRoute);
+
+    it('should have working top level route inside child route folder', tests.verifyNestedTopRoute);
+
+    afterAll((done) => {
+      common.removeAppFile('test/#child/top/index.html')
+        .then(() => common.writeAppFile('index.html', '<my-home></my-home>'))
+        .then(() => common.removeAppFile('test/#child/index.html'))
+        .then(() => common.removeAppFile('test/index.html'))
+        .then(() => common.removeAppFolder('test/#child/top'))
+        .then(() => common.removeAppFolder('test/#child'))
+        .then(() => common.removeAppFolder('test'))
+        .then(() => common.afterAll())
+        .then(done)
+        .catch(console.error);
+    });
+  });
 });

--- a/lib/sky-pages-route-generator.js
+++ b/lib/sky-pages-route-generator.js
@@ -122,22 +122,60 @@ function generateDefinitions(routes) {
   return routes.map(route => route.componentDefinition).join('\n\n');
 }
 
+function generateRouteDeclaration(route) {
+  let guard = route.guard ? route.guard.name : '';
+  let childRoutes = '';
+  route.children.forEach(child => childRoutes += generateRouteDeclaration(child));
+
+  return `{
+    path: '${route.routePath}',
+    component: ${route.componentName},
+    canActivate: [${guard}],
+    canDeactivate: [${guard}],
+    canActivateChild: [${guard}],
+    children: [${childRoutes}]
+  }`;
+}
+
+function mapRoutes(routes, mappedRoutes = [], routeMap = {}) {
+  const unmappedRoutes = [];
+
+  routes.forEach(route => {
+    if (route.routePath.indexOf('/') === -1) {
+      mappedRoutes.push(route);
+      routeMap[route.routePath] = route;
+      route.children = [];
+    } else {
+      const routeParentPath = route.routePath.substring(0, route.routePath.lastIndexOf('/'));
+      const routeParent = routeMap[routeParentPath];
+      if (routeParent) {
+        routeParent.children.push(route);
+        routeMap[route.routePath] = route;
+        route.routePath = route.routePath.substring(routeParentPath.length + 1);
+        route.children = [];
+      } else {
+        unmappedRoutes.push(route);
+      }
+    }
+  });
+
+  // if we have managed to map at least one route
+  // but still have unmapped routes, recurse!
+  if (mappedRoutes.length > 1 && unmappedRoutes.length > 0) {
+    return mapRoutes(routes, mappedRoutes, routeMap);
+  }
+
+  return mappedRoutes;
+}
+
 function generateDeclarations(routes) {
   const p = indent(1);
-  const declarations = routes
-    .map(r => {
-      let guard = r.guard ? r.guard.name : '';
-      let declaration =
-`${p}{
-  path: '${r.routePath}',
-  component: ${r.componentName},
-  canActivate: [${guard}],
-  canDeactivate: [${guard}]
-}`;
 
-      return declaration;
-    })
+  const mappedRoutes = mapRoutes(routes);
+  const declarations = mappedRoutes
+    .map(r => generateRouteDeclaration(r))
     .join(',\n');
+
   return `[\n${declarations}\n]`;
 }
 

--- a/lib/sky-pages-route-generator.js
+++ b/lib/sky-pages-route-generator.js
@@ -270,7 +270,7 @@ function generateNames(routes) {
 // Specifically routeDefinition caused errors for skyux e2e in Windows.
 function getRoutesForConfig(routes) {
   return routes.map(route => ({
-    routePath: route.routePath,
+    routePath: route.routePath === '~' ? '' : route.routePath.replace(/\#/g, ''),
     routeParams: route.routeParams
   }));
 }

--- a/lib/sky-pages-route-generator.js
+++ b/lib/sky-pages-route-generator.js
@@ -106,6 +106,14 @@ function generateRoutes(skyAppConfig) {
     .sync(path.join(skyAppConfig.runtime.srcPath, skyAppConfig.runtime.routesPattern))
     .map(file => parseFileIntoEntity(skyAppConfig, file, counter++));
 
+  // Add a root component that will become the wrapper for all the others
+  entities.push({
+    routePath: ['~'], // we need a non-empty route path so it won't be merged later
+    componentName: 'RootComponent',
+    componentDefinition:
+      `@Component({ template: '<router-outlet></router-outlet>' }) export class RootComponent {}`
+  });
+
   if (skyAppConfig.runtime.handle404) {
     entities.push({
       componentName: 'NotFoundComponent',
@@ -123,9 +131,10 @@ function generateDefinitions(routes) {
 }
 
 function generateRouteDeclaration(route) {
-  let guard = route.guard ? route.guard.name : '';
-  let childRoutes = '';
-  route.children.forEach(child => childRoutes += generateRouteDeclaration(child));
+  const guard = route.guard ? route.guard.name : '';
+  const childRoutes = route.children
+    .map(child => generateRouteDeclaration(child))
+    .join(',\n');
 
   return `{
     path: '${route.routePath}',
@@ -137,42 +146,105 @@ function generateRouteDeclaration(route) {
   }`;
 }
 
-function mapRoutes(routes, mappedRoutes = [], routeMap = {}) {
-  const unmappedRoutes = [];
+function parseRoute(route) {
+  let result;
+  route.routePath = (route.routePath || '').toString();
+
+  const routeTokens = route.routePath.split('/');
+  const lastToken = routeTokens[routeTokens.length - 1];
+
+  if (lastToken.startsWith('#')) {
+    const reversedTokens = routeTokens.slice().reverse();
+    const childTokens = [lastToken];
+    for (let i = 1; i < reversedTokens.length; i++) {
+      let token = reversedTokens[i];
+      if (token.startsWith('#')) {
+        childTokens.push(token);
+      } else {
+        break;
+      }
+    }
+
+    result = {
+      routePath: routeTokens.slice(0, routeTokens.length - childTokens.length).join('/'),
+      children: []
+    };
+
+    let currentRoute = result;
+    childTokens.reverse().forEach(token => {
+      let childToken = {
+        routePath: token.substring(1),
+        children: []
+      };
+
+      if (token === lastToken) {
+        childToken.componentName = route.componentName;
+        childToken.guard = route.guard;
+      }
+
+      currentRoute.children.push(childToken);
+      currentRoute = childToken;
+    });
+  } else {
+    result = {
+      routePath: route.routePath,
+      guard: route.guard,
+      componentName: route.componentName,
+      children: []
+    };
+  }
+
+  result.routePath = result.routePath.replace(/\#/g, '');
+  return result;
+}
+
+function mergeRoutes(routes) {
+  const routeIndex = {};
+  const uniqueRoutes = [];
 
   routes.forEach(route => {
-    if (route.routePath.indexOf('/') === -1) {
-      mappedRoutes.push(route);
-      routeMap[route.routePath] = route;
-      route.children = [];
-    } else {
-      const routeParentPath = route.routePath.substring(0, route.routePath.lastIndexOf('/'));
-      const routeParent = routeMap[routeParentPath];
-      if (routeParent) {
-        routeParent.children.push(route);
-        routeMap[route.routePath] = route;
-        route.routePath = route.routePath.substring(routeParentPath.length + 1);
-        route.children = [];
-      } else {
-        unmappedRoutes.push(route);
+    const existingRoute = routeIndex[route.routePath];
+    if (existingRoute) {
+      route.children.forEach(rc => existingRoute.children.push(rc));
+      existingRoute.children = mergeRoutes(existingRoute.children);
+
+      if (route.componentName) {
+        existingRoute.componentName = route.componentName;
       }
+
+      if (route.guard) {
+        existingRoute.guard = route.guard;
+      }
+    } else {
+      routeIndex[route.routePath] = route;
+      uniqueRoutes.push(route);
     }
   });
 
-  // if we have managed to map at least one route
-  // but still have unmapped routes, recurse!
-  if (mappedRoutes.length > 1 && unmappedRoutes.length > 0) {
-    return mapRoutes(routes, mappedRoutes, routeMap);
-  }
-
-  return mappedRoutes;
+  return uniqueRoutes;
 }
 
 function generateDeclarations(routes) {
-  const p = indent(1);
+  let mappedRoutes = mergeRoutes(routes.map(r => parseRoute(r)));
 
-  const mappedRoutes = mapRoutes(routes);
-  const declarations = mappedRoutes
+  // nest all routes under a top-level route to allow for app-wide guard
+  // steal guard from app/index component, if exists
+  const baseRoutes = mappedRoutes.filter(e => e.routePath === '~' || e.routePath === '**');
+  const rootRoute = baseRoutes[0];
+
+  const indexRoute = mappedRoutes.filter(e => e.routePath === '' && e.guard)[0];
+  if (indexRoute) {
+    rootRoute.guard = indexRoute.guard;
+    indexRoute.guard = null;
+  }
+
+  mappedRoutes
+    .filter(e => e.routePath !== '~' && e.routePath !== '**')
+    .forEach(e => rootRoute.children.push(e));
+
+  // reset root route path to ''
+  rootRoute.routePath = '';
+  const declarations = baseRoutes
     .map(r => generateRouteDeclaration(r))
     .join(',\n');
 

--- a/lib/sky-pages-route-generator.js
+++ b/lib/sky-pages-route-generator.js
@@ -131,7 +131,6 @@ function generateDefinitions(routes) {
 }
 
 function generateRouteDeclaration(route) {
-  const guard = route.guard ? route.guard.name : '';
   const childRoutes = route.children
     .map(child => generateRouteDeclaration(child))
     .join(',\n');
@@ -139,9 +138,9 @@ function generateRouteDeclaration(route) {
   return `{
     path: '${route.routePath}',
     component: ${route.componentName},
-    canActivate: [${guard}],
-    canDeactivate: [${guard}],
-    canActivateChild: [${guard}],
+    canActivate: [${route.guard && route.guard.canActivate ? route.guard.name : ''}],
+    canDeactivate: [${route.guard && route.guard.canDeactivate ? route.guard.name : ''}],
+    canActivateChild: [${route.guard && route.guard.canActivateChild ? route.guard.name : ''}],
     children: [${childRoutes}]
   }`;
 }
@@ -299,7 +298,13 @@ function extractGuard(file) {
       throw new Error(`As a best practice, only export one guard per file in ${file}`);
     }
 
-    result = { path: path.resolve(file), name: match[1] };
+    result = {
+      path: path.resolve(file),
+      name: match[1],
+      canActivate: content.match(/canActivate\s*\(/g) !== null,
+      canDeactivate: content.match(/canDeactivate\s*\(/g) !== null,
+      canActivateChild: content.match(/canActivateChild\s*\(/g) !== null
+    };
   }
 
   return result;

--- a/test/sky-pages-route-generator.spec.js
+++ b/test/sky-pages-route-generator.spec.js
@@ -106,7 +106,11 @@ describe('SKY UX Builder route generator', () => {
 
   it('should support guards with custom routesPattern', () => {
     spyOn(glob, 'sync').and.callFake(() => ['my-custom-src/my-custom-route/index.html']);
-    spyOn(fs, 'readFileSync').and.returnValue('@Injectable() export class Guard {}');
+    spyOn(fs, 'readFileSync').and.returnValue(`@Injectable() export class Guard {
+      canActivate() {}
+      canDeactivate() {}
+      canActivateChild() {}
+    }`);
     spyOn(fs, 'existsSync').and.returnValue(true);
 
     let routes = generator.getRoutes({
@@ -122,6 +126,10 @@ describe('SKY UX Builder route generator', () => {
 
     expect(routes.declarations).toContain(
       `canDeactivate: [Guard]`
+    );
+
+    expect(routes.declarations).toContain(
+      `canActivateChild: [Guard]`
     );
 
     expect(routes.providers).toContain(

--- a/test/sky-pages-route-generator.spec.js
+++ b/test/sky-pages-route-generator.spec.js
@@ -153,4 +153,104 @@ describe('SKY UX Builder route generator', () => {
       }
     })).toThrow(new Error(`As a best practice, only export one guard per file in ${file}`));
   });
+
+  it('should handle top-level routes', () => {
+    spyOn(glob, 'sync').and.callFake(() => ['my-custom-src/my-custom-route/index.html']);
+    spyOn(path, 'join').and.returnValue('');
+    const routes = generator.getRoutes({
+      runtime: {
+        srcPath: ''
+      }
+    });
+
+    expect(routes.declarations).toContain(
+      `path: 'my-custom-src/my-custom-route'`
+    );
+  });
+
+  it('should handle child routes', () => {
+    spyOn(glob, 'sync').and.callFake(() => ['my-custom-src/#my-custom-route/index.html']);
+    spyOn(path, 'join').and.returnValue('');
+    const routes = generator.getRoutes({
+      runtime: {
+        srcPath: ''
+      }
+    });
+
+    expect(routes.declarations).toContain(
+      `path: 'my-custom-src'`
+    );
+
+    expect(routes.declarations).toContain(
+      `path: 'my-custom-route'`
+    );
+  });
+
+  it('should handle nested child routes', () => {
+    spyOn(glob, 'sync').and.callFake(() => ['my-custom-src/#my-custom-route/#nested/index.html']);
+    spyOn(path, 'join').and.returnValue('');
+    const routes = generator.getRoutes({
+      runtime: {
+        srcPath: ''
+      }
+    });
+
+    expect(routes.declarations).toContain(
+      `path: 'my-custom-src'`
+    );
+
+    expect(routes.declarations).toContain(
+      `path: 'my-custom-route'`
+    );
+
+    expect(routes.declarations).toContain(
+      `path: 'nested'`
+    );
+  });
+
+  it('should merge child routes when necessary', () => {
+    spyOn(glob, 'sync').and.callFake(() => [
+      'my-custom-src/#my-custom-route/#nested/index.html',
+      'my-custom-src/#my-custom-route/index.html',
+      ''
+    ]);
+    spyOn(fs, 'readFileSync').and.returnValue(`@Injectable() export class Guard {
+      canActivate() {}
+      canDeactivate() {}
+      canActivateChild() {}
+    }`);
+    spyOn(fs, 'existsSync').and.returnValue(true);
+    spyOn(path, 'join').and.returnValue('');
+    const routes = generator.getRoutes({
+      runtime: {
+        srcPath: ''
+      }
+    });
+
+    expect(routes.declarations).toContain(
+      `path: 'my-custom-src'`
+    );
+
+    expect(routes.declarations).toContain(
+      `path: 'my-custom-route'`
+    );
+
+    expect(routes.declarations).toContain(
+      `path: 'nested'`
+    );
+  });
+
+  it('should handle top-level routes within a child route', () => {
+    spyOn(glob, 'sync').and.callFake(() => ['my-custom-src/#my-custom-route/top-level/index.html']);
+    spyOn(path, 'join').and.returnValue('');
+    const routes = generator.getRoutes({
+      runtime: {
+        srcPath: ''
+      }
+    });
+
+    expect(routes.declarations).toContain(
+      `path: 'my-custom-src/my-custom-route/top-level'`
+    );
+  });
 });

--- a/test/sky-pages-route-generator.spec.js
+++ b/test/sky-pages-route-generator.spec.js
@@ -227,14 +227,10 @@ describe('SKY UX Builder route generator', () => {
       }
     });
 
-    expect(routes.declarations).toContain(
-      `path: 'my-custom-src'`
-    );
-
-    expect(routes.declarations).toContain(
-      `path: 'my-custom-route'`
-    );
-
+    // expect only one instance each of `my-custom-src` and `my-custom-route`
+    // in the declarations
+    expect(routes.declarations.match(/path\:\s\'my\-custom\-src\'/g).length).toBe(1);
+    expect(routes.declarations.match(/path\:\s\'my\-custom\-route\'/g).length).toBe(1);
     expect(routes.declarations).toContain(
       `path: 'nested'`
     );


### PR DESCRIPTION
PR implements child routing based on the design @Blackbaud-PaulCrowder and I discussed yesterday.

A directory prefixed with `#` such as `src/app/about/#child` would create a child-route underneath `/about` which can be affected by `canActivateChild` guards as well as used by controls that implement `router-outlet` in their template such as the future tab control (or currently microedge contrib tab control).

A directory without the prefix but underneath a child route such as `src/app/about/#child/top-level` will break out and become a top level route that cannot be affected by `canActivateChild` guards and will not participate in `router-outlet`.

All other routes will continue to be top-level. Routes continue to only be created if an `index.html` is provided.

Additionally now that we have child routing, I've also implemented a top-level route that makes it very simple to declare an `index.guard.ts` next to `src/app/index.html` and have a guard that affects being able to load *anything* within the SPA. This should be the preferred method for locking down SPAs in future.

Added several e2e tests to validate the functionality as well as unit tests for the route generation.