### PR TITLE
Stop resolving, fix windows guard paths

### DIFF
--- a/lib/sky-pages-route-generator.js
+++ b/lib/sky-pages-route-generator.js
@@ -141,10 +141,11 @@ function generateDeclarations(routes) {
   return `[\n${declarations}\n]`;
 }
 
-function generateRuntimeImports(routes) {
+function generateRuntimeImports(skyAppConfig, routes) {
+  const alias = skyAppConfig.runtime.spaPathAlias;
   return routes
     .filter(r => r.guard)
-    .map(r => `import { ${r.guard.name} } from '${r.guard.path.replace(/\.ts$/, '')}';`);
+    .map(r =>`import { ${r.guard.name} } from '${alias}/${r.guard.path.replace(/\.ts$/, '')}';`);
 }
 
 function generateProviders(routes) {
@@ -171,7 +172,7 @@ function getRoutes(skyAppConfig) {
   return {
     declarations: generateDeclarations(routes),
     definitions: generateDefinitions(routes),
-    imports: generateRuntimeImports(routes),
+    imports: generateRuntimeImports(skyAppConfig, routes),
     providers: generateProviders(routes),
     names: generateNames(routes),
     routesForConfig: getRoutesForConfig(routes)
@@ -189,7 +190,7 @@ function extractGuard(file) {
       throw new Error(`As a best practice, only export one guard per file in ${file}`);
     }
 
-    result = { path: path.resolve(file), name: match[1] };
+    result = { path: file.replace(/\\/g, '/'), name: match[1] };
   }
 
   return result;

--- a/test/sky-pages-route-generator.spec.js
+++ b/test/sky-pages-route-generator.spec.js
@@ -104,6 +104,41 @@ describe('SKY UX Builder route generator', () => {
     expect(suppliedPattern).toEqual('my-custom-src/my-custom-pattern');
   });
 
+  it('should handle windows guard paths correctly', () => {
+    spyOn(glob, 'sync').and.callFake(() => ['my-src\\my-custom-route\\index.html']);
+    spyOn(fs, 'readFileSync').and.returnValue('@Injectable() export class Guard {}');
+    spyOn(fs, 'existsSync').and.returnValue(true);
+
+    let routes = generator.getRoutes({
+      runtime: {
+        srcPath: 'my-src',
+        routesPattern: '**/index.html'
+      }
+    });
+
+    expect(routes.imports[0]).toContain(
+      `my-src/my-custom-route/index.guard`
+    );
+  });
+
+  it('should prefix guard imports with spaPathAlias', () => {
+    spyOn(glob, 'sync').and.callFake(() => ['my-src/my-custom-route/index.html']);
+    spyOn(fs, 'readFileSync').and.returnValue('@Injectable() export class Guard {}');
+    spyOn(fs, 'existsSync').and.returnValue(true);
+
+    let routes = generator.getRoutes({
+      runtime: {
+        srcPath: '',
+        routesPattern: '**/index.html',
+        spaPathAlias: 'spa-path-alias'
+      }
+    });
+
+    expect(routes.imports[0]).toContain(
+      `import { Guard } from \'spa-path-alias/my-src/my-custom-route/index.guard\';`
+    );
+  });
+
   it('should support guards with custom routesPattern', () => {
     spyOn(glob, 'sync').and.callFake(() => ['my-custom-src/my-custom-route/index.html']);
     spyOn(fs, 'readFileSync').and.returnValue('@Injectable() export class Guard {}');


### PR DESCRIPTION
Fixes the bathing to use the runtime alias. Also flips `\` to `/` for module loading on windows. Confirmed fix on Win7 and OSX.