### PR TITLE
Param functionality

### DIFF
--- a/runtime/params.spec.ts
+++ b/runtime/params.spec.ts
@@ -64,4 +64,13 @@ describe('SkyAppRuntimeConfigParams', () => {
     expect(params.getUrl('https://mysite.com')).toEqual('https://mysite.com');
   });
 
+  it('should allow querystring param keys to be case insensitive', () => {
+    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
+      '?A1=b&A3=c',
+      allowed
+    );
+    expect(params.get('a1')).toEqual('b');
+    expect(params.get('a3')).toEqual('c');
+  });
+
 });

--- a/runtime/params.spec.ts
+++ b/runtime/params.spec.ts
@@ -73,4 +73,14 @@ describe('SkyAppRuntimeConfigParams', () => {
     expect(params.get('a3')).toEqual('c');
   });
 
+  it('should expose a `has` method for testing if a param exists', () => {
+    const params: SkyAppRuntimeConfigParams = new SkyAppRuntimeConfigParams(
+      '?a1=b&a2=c',
+      allowed
+    );
+    expect(params.has('a1')).toEqual(true);
+    expect(params.has('a2')).toEqual(false);
+    expect(params.has('a3')).toEqual(false);
+  });
+
 });

--- a/runtime/params.ts
+++ b/runtime/params.ts
@@ -25,11 +25,18 @@ export class SkyAppRuntimeConfigParams {
 
     const urlSearchParams: URLSearchParams = getUrlSearchParams(this.url);
 
+    // Get uppercase keys
+    const allowedKeysUC: string[] = this.allowed.map(key => key.toUpperCase());
+    const urlSearchParamKeys: string[] = Array.from(urlSearchParams.paramsMap.keys());
+
     // Filter to allowed params
-    this.allowed.forEach(key => {
-      if (urlSearchParams.has(key)) {
-        this.params[key] = urlSearchParams.get(key);
-      }
+    urlSearchParamKeys.forEach(givenKey => {
+      const givenKeyUC: string = givenKey.toUpperCase();
+      allowedKeysUC.forEach((allowedKeyUC, index) => {
+        if (givenKeyUC === allowedKeyUC) {
+          this.params[this.allowed[index]] = urlSearchParams.get(givenKey);
+        }
+      });
     });
   }
 

--- a/runtime/params.ts
+++ b/runtime/params.ts
@@ -41,16 +41,24 @@ export class SkyAppRuntimeConfigParams {
   }
 
   /**
+   * Does the key exist
+   * @param {string} key
+   * @returns {boolean}
+   */
+  public has(key: string): boolean {
+    return this.params && this.params.hasOwnProperty(key);
+  }
+
+  /**
    * Returns the value of the requested param.
    * @name get
    * @param {string} key
    * @returns {string}
    */
   public get(key: string): string {
-    if (this.params && this.params[key]) {
+    if (this.has(key)) {
       return this.params[key];
     }
-    return '';
   }
 
   /**

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -31,7 +31,7 @@ describe('AppComponent', () => {
         base: 'app-base'
       },
       params: {
-        getAllKeys: () => [],
+        has: (key) => false,
         parse: (p) => parseParams = p
       }
     },
@@ -166,31 +166,20 @@ describe('AppComponent', () => {
     });
   }));
 
-  it('should set the allowed params on the omnibar config', async(() => {
+  it('should set the known params on the omnibar config if they exist', async(() => {
     let spyOmnibar = spyOn(BBOmnibar, 'load');
     skyAppConfig.skyux.omnibar = {};
 
-    // Bypassing the allowed params functionality
-    skyAppConfig.runtime.params.getAllKeys = () => ['asdf'];
-    skyAppConfig.runtime.params.get = (key) => 'jkl';
-    setup(skyAppConfig, true).then(() => {
-      fixture.detectChanges();
-      expect(spyOmnibar.calls.first().args[0].asdf).toEqual('jkl');
-    });
-  }));
-
-  it('should use the omnibarConfigMap key if it exists', async(() => {
-    let spyOmnibar = spyOn(BBOmnibar, 'load');
-    skyAppConfig.skyux.omnibar = {};
-
-    // Bypassing the allowed params functionality
-    skyAppConfig.runtime.params.getAllKeys = () => ['envid', 'svcid'];
+    skyAppConfig.skyux.params = ['envid', 'svcid'];
+    skyAppConfig.runtime.params.has = (key) => true;
     skyAppConfig.runtime.params.get = (key) => key + 'Value';
     setup(skyAppConfig, true).then(() => {
       fixture.detectChanges();
 
-      // Notice envid => envId and svid => svcId
+      // Notice envid => envId
       expect(spyOmnibar.calls.first().args[0].envId).toEqual('envidValue');
+
+      // Notice svcid => svcId
       expect(spyOmnibar.calls.first().args[0].svcId).toEqual('svcidValue');
     });
   }));

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -181,14 +181,15 @@ describe('AppComponent', () => {
   it('should use the omnibarConfigMap key if it exists', async(() => {
     let spyOmnibar = spyOn(BBOmnibar, 'load');
     skyAppConfig.skyux.omnibar = {};
-    skyAppConfig.skyux.params = ['envid'];
-    skyAppConfig.runtime.params.getAllKeys = () => ['envid'];
-    skyAppConfig.runtime.params.get = (key) => 'envidValue';
+    skyAppConfig.skyux.params = ['asdf'];
+    skyAppConfig.runtime.params.getAllKeys = () => ['envid', 'svcid'];
+    skyAppConfig.runtime.params.get = (key) => key + 'Value';
     setup(skyAppConfig, true).then(() => {
       fixture.detectChanges();
 
-      // Notice envid => envId
+      // Notice envid => envId and svid => svcId
       expect(spyOmnibar.calls.first().args[0].envId).toEqual('envidValue');
+      expect(spyOmnibar.calls.first().args[0].svcId).toEqual('svcidValue');
     });
   }));
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -169,7 +169,8 @@ describe('AppComponent', () => {
   it('should set the allowed params on the omnibar config', async(() => {
     let spyOmnibar = spyOn(BBOmnibar, 'load');
     skyAppConfig.skyux.omnibar = {};
-    skyAppConfig.skyux.params = ['asdf'];
+
+    // Bypassing the allowed params functionality
     skyAppConfig.runtime.params.getAllKeys = () => ['asdf'];
     skyAppConfig.runtime.params.get = (key) => 'jkl';
     setup(skyAppConfig, true).then(() => {
@@ -181,7 +182,8 @@ describe('AppComponent', () => {
   it('should use the omnibarConfigMap key if it exists', async(() => {
     let spyOmnibar = spyOn(BBOmnibar, 'load');
     skyAppConfig.skyux.omnibar = {};
-    skyAppConfig.skyux.params = ['asdf'];
+
+    // Bypassing the allowed params functionality
     skyAppConfig.runtime.params.getAllKeys = () => ['envid', 'svcid'];
     skyAppConfig.runtime.params.get = (key) => key + 'Value';
     setup(skyAppConfig, true).then(() => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -103,7 +103,7 @@ export class AppComponent implements OnInit {
   private setParamsFromQS(omnibarConfig: any) {
     const omnibarConfigMap: {[key: string]: string} = {
       envid: 'envId',
-      svid: 'svcId'
+      svcid: 'svcId'
     };
     this.config.runtime.params.getAllKeys().forEach(key => {
       const omnibarConfigKey = omnibarConfigMap[key] || key;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -100,15 +100,14 @@ export class AppComponent implements OnInit {
   }
 
   // Only pass params that omnibar config cares about
+  // Internally we store as envid/svcid but auth-client wants envId/svcId
   private setParamsFromQS(omnibarConfig: any) {
-    const omnibarConfigMap: {[key: string]: string} = {
-      envid: 'envId',
-      svcid: 'svcId'
-    };
-    this.config.runtime.params.getAllKeys().forEach(key => {
-      const omnibarConfigKey = omnibarConfigMap[key] || key;
-      omnibarConfig[omnibarConfigKey] = this.config.runtime.params.get(key);
-    });
+    if (this.config.runtime.params.has('envid')) {
+      omnibarConfig.envId = this.config.runtime.params.get('envid');
+    }
+    if (this.config.runtime.params.has('svcid')) {
+      omnibarConfig.svcId = this.config.runtime.params.get('svcid');
+    }
   }
 
   private setOnSearch(omnibarConfig: any) {


### PR DESCRIPTION
- Fixed typo in OmnibarConfigMap (`svid` -> `svcid`)
- Allowing query string params to be case insensitive (uses case specified in `skyuxconfig.json` when setting)