### PR TITLE
Wrote failing test.  Then made config property public for template

### DIFF
--- a/lib/sky-pages-route-generator.js
+++ b/lib/sky-pages-route-generator.js
@@ -34,7 +34,7 @@ export class ${name} implements OnInit, OnDestroy {
 ${paramDeclarations}
   constructor(
     private route: ActivatedRoute,
-    private config: SkyAppConfig
+    public config: SkyAppConfig
   ) { }
 
   public ngOnInit() {

--- a/test/sky-pages-route-generator.spec.js
+++ b/test/sky-pages-route-generator.spec.js
@@ -284,4 +284,17 @@ describe('SKY UX Builder route generator', () => {
       `path: 'my-custom-src/my-custom-route/top-level'`
     );
   });
+
+  it('should publicly expose config variable to template', () => {
+    spyOn(glob, 'sync').and.returnValue(['custom/nested/index.html']);
+    spyOn(path, 'join').and.returnValue('');
+    spyOn(fs, 'readFileSync').and.returnValue('');
+
+    const routes = generator.getRoutes({
+      runtime: {
+        srcPath: ''
+      }
+    });
+    expect(routes.definitions).toContain('public config: SkyAppConfig');
+  });
 });


### PR DESCRIPTION
Due to updated AoT rules, `config` needs to be marked as public in order to be accessible in an auto-generated component's template (`index.html`).

@blackbaud-johnly, we'll also need to update https://developer.blackbaud.com/skyux2/learn/reference/configuration/apply-appsettings to show it being `public`.