### PR TITLE
Removed preloader from AoT Webpack config

### DIFF
--- a/config/webpack/build-aot.webpack.config.js
+++ b/config/webpack/build-aot.webpack.config.js
@@ -19,6 +19,14 @@ function getWebpackConfig(skyPagesConfig) {
   let commonConfig = common.getWebpackConfig(skyPagesConfig);
   commonConfig.entry = null;
 
+  // Since the preloader is executed against the file system during an AoT build,
+  // we need to remove it from the webpack config, otherwise it will get executed twice.
+  commonConfig.module.rules = commonConfig.module.rules
+    .filter((rule) => {
+      const isPreloader = /\/sky-processor\//.test(rule.loader);
+      return (!isPreloader);
+    });
+
   return webpackMerge(commonConfig, {
     entry: {
       polyfills: [skyPagesConfigUtil.spaPathTempSrc('polyfills.ts')],

--- a/test/config-webpack-build-aot.spec.js
+++ b/test/config-webpack-build-aot.spec.js
@@ -193,4 +193,40 @@ describe('config webpack build-aot', () => {
     });
   });
 
+  it('should remove the sky-processor loader from the rules array', () => {
+    const f = './common.webpack.config';
+    mock(f, {
+      getWebpackConfig: () => ({
+        module: {
+          rules: [
+            {
+              loader: '/sky-processor/'
+            }
+          ]
+        }
+      })
+    });
+
+    const lib = require('../config/webpack/build-aot.webpack.config');
+
+    const skyPagesConfig = {
+      runtime: runtimeUtils.getDefaultRuntime(),
+      skyux: {}
+    };
+
+    const config = lib.getWebpackConfig(skyPagesConfig);
+
+    let found = false;
+
+    config.module.rules.forEach((rule) => {
+      if (found) {
+        return;
+      }
+
+      found = /\/sky-processor\//.test(rule.loader);
+    });
+
+    expect(found).toEqual(false);
+  });
+
 });

--- a/test/config-webpack-build-aot.spec.js
+++ b/test/config-webpack-build-aot.spec.js
@@ -18,7 +18,7 @@ describe('config webpack build-aot', () => {
   });
 
   afterEach(() => {
-    mock.stop(ngtoolsWebpackPath);
+    mock.stopAll();
   });
 
   it('should expose a getWebpackConfig method', () => {


### PR DESCRIPTION
Since the preloader is executed on the file system during an AoT build, the loader is run twice: once, during the [webpack build](https://github.com/blackbaud/skyux-builder/blob/master/config/webpack/common.webpack.config.js#L95), and second, in the [`stageAot`](https://github.com/blackbaud/skyux-builder/blob/master/cli/build.js#L108) method.

This duplicate behavior causes plugins to process files twice during AoT, causing things like this (the double-escaped brackets):
https://developer.blackbaud.com/skyux2/learn/reference/configuration

<img width="303" alt="screen shot 2017-07-13 at 11 28 02 pm" src="https://user-images.githubusercontent.com/12497062/28197153-f0fea7b8-6822-11e7-80a0-2c728f5a02d2.png">

