### PR TITLE
Updated font families in style loader

### DIFF
--- a/config/protractor/protractor-dev.conf.js
+++ b/config/protractor/protractor-dev.conf.js
@@ -20,7 +20,7 @@ let config = {
 
     return new Promise((resolve, reject) => {
       const url = 'https://github.com/blackbaud/skyux-template';
-      const branch = 'master';
+      const branch = 'builder-dev';
 
       common.rimrafPromise(common.tmp)
         .then(() => common.exec(`git`, [

--- a/runtime/style-loader.ts
+++ b/runtime/style-loader.ts
@@ -9,8 +9,7 @@ export class SkyAppStyleLoader {
 
   public loadStyles(): Promise<any> {
     const fontAwesome = new FontFaceObserver('FontAwesome');
-    const openSans = new FontFaceObserver('Open Sans');
-    const oswald = new FontFaceObserver('Oswald');
+    const blackbaudSans = new FontFaceObserver('Blackbaud Sans');
 
     return Promise
       .all([
@@ -18,8 +17,7 @@ export class SkyAppStyleLoader {
         // when the font is loaded unless a known character with a different width
         // than the default is not specified.
         fontAwesome.load('\uf0fc', SkyAppStyleLoader.LOAD_TIMEOUT),
-        openSans.load(undefined, SkyAppStyleLoader.LOAD_TIMEOUT),
-        oswald.load(undefined, SkyAppStyleLoader.LOAD_TIMEOUT)
+        blackbaudSans.load(undefined, SkyAppStyleLoader.LOAD_TIMEOUT)
       ])
       .then(() => {
         this.isLoaded = true;

--- a/utils/sky-style-loader.js
+++ b/utils/sky-style-loader.js
@@ -13,8 +13,7 @@ var LOAD_TIMEOUT = 30000;
 module.exports = {
   loadStyles: function () {
     var fontAwesome = new FontFaceObserver('FontAwesome');
-    var openSans = new FontFaceObserver('Open Sans');
-    var oswald = new FontFaceObserver('Oswald');
+    var blackbaudSans = new FontFaceObserver('Blackbaud Sans');
     var promise;
 
     promise = Promise.all(
@@ -23,8 +22,7 @@ module.exports = {
         // when the font is loaded unless a known character with a different width
         // than the default is not specified.
         fontAwesome.load('\uf0fc', LOAD_TIMEOUT),
-        openSans.load(null, LOAD_TIMEOUT),
-        oswald.load(null, LOAD_TIMEOUT)
+        blackbaudSans.load(null, LOAD_TIMEOUT)
       ]
     );
 


### PR DESCRIPTION
Since the font families have changed in SKY UX rc.7, the style loader doesn't resolve in time and causes Jasmine tests to timeout.