### PR TITLE
Fix: Added specific version of enhanced-resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "awesome-typescript-loader": "3.1.3",
     "codelyzer": "3.0.1",
     "core-js": "2.4.1",
+    "enhanced-resolve": "3.3.0",
     "fontfaceobserver": "2.0.9",
     "fs-extra": "3.0.1",
     "glob": "7.1.1",


### PR DESCRIPTION
`@ngtools/webpack@1.3.1` created a transient dependecy for `enhanced-resolve`, which prevents `skyux build` from completing.

More information:
https://github.com/angular/angular-cli/issues/7113
