### PR TITLE
Fixed TSLint checking node_modules

### DIFF
--- a/cli/utils/ts-linter.js
+++ b/cli/utils/ts-linter.js
@@ -11,19 +11,34 @@ const flags = [
   '--project',
   skyPagesConfigUtil.spaPath('tsconfig.json'),
   '--config',
-  skyPagesConfigUtil.spaPath('tslint.json')
+  skyPagesConfigUtil.spaPath('tslint.json'),
+  '--exclude',
+  '**/node_modules/**/*.ts'
 ];
 
 function lintSync() {
   logger.info('Starting TSLint...');
 
   const spawnResult = spawn.sync('./node_modules/.bin/tslint', flags);
-  const errorString = spawnResult.stderr.toString().trim();
 
+  // Convert buffers to strings.
+  let output = [];
+  spawnResult.output.forEach((buffer) => {
+    if (buffer === null) {
+      return;
+    }
+
+    const str = buffer.toString().trim();
+    if (str) {
+      output.push(str);
+    }
+  });
+
+  // Convert multi-line errors into single errors.
   let errors = [];
-  if (errorString) {
-    errors = errorString.split(/\r?\n/);
-  }
+  output.forEach((str) => {
+    errors = errors.concat(str.split(/\r?\n/));
+  });
 
   // Print linting results to console.
   errors.forEach(error => logger.error(error));

--- a/test/cli-utils-ts-linter.spec.js
+++ b/test/cli-utils-ts-linter.spec.js
@@ -29,7 +29,7 @@ describe('cli util ts-linter', () => {
         _executed = true;
         return {
           status: 0,
-          stderr: new Buffer('')
+          output: [new Buffer('some error')]
         };
       }
     });
@@ -49,7 +49,7 @@ describe('cli util ts-linter', () => {
       sync: () => {
         return {
           status: 1,
-          stderr: new Buffer('Error: something bad happened.')
+          output: [new Buffer('some error'), new Buffer('another error')]
         };
       }
     });
@@ -57,5 +57,25 @@ describe('cli util ts-linter', () => {
     const result = tsLinter.lintSync();
     expect(result.exitCode).toEqual(1);
     expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('should not log an error if linting errors are not found', () => {
+    spyOn(logger, 'info').and.returnValue();
+    spyOn(logger, 'error').and.returnValue();
+    mock('../config/sky-pages/sky-pages.config', {
+      spaPath: (filePath) => filePath
+    });
+    mock('cross-spawn', {
+      sync: () => {
+        return {
+          status: 0,
+          output: [null, new Buffer('')]
+        };
+      }
+    });
+    const tsLinter = mock.reRequire('../cli/utils/ts-linter');
+    const result = tsLinter.lintSync();
+    expect(result.exitCode).toEqual(0);
+    expect(logger.error).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
- TSLint was only logging `stderr` and ignoring `stdout`. However, the status code would return as non-zero because the `stdout` reported linting errors in node_modules.
- To avoid this, I'm excluding node_modules for the TSLint CLI, as well as parsing the entire child process output for messages.