### PR TITLE
Disabled gecko for webdriver-manger update

### DIFF
--- a/cli/e2e.js
+++ b/cli/e2e.js
@@ -132,7 +132,7 @@ function spawnSelenium() {
         'webdriver-manager'
       );
 
-      let results = spawn.sync(webdriverManagerPath, ['update'], spawnOptions);
+      let results = spawn.sync(webdriverManagerPath, ['update', '--gecko', 'false'], spawnOptions);
 
       if (results.error) {
         reject(results.error);


### PR DESCRIPTION
Fixes https://github.com/blackbaud/skyux2/issues/1009

Since we, currently, only use Chrome in our selenium tests, we can add this flag to disable pulling down the gecko driver.  If we ever add Firefox to our test suite, we'll need to make sure to disable this.