### PR TITLE
Change toHaveText to have a more verbose error message

### DIFF
--- a/runtime/testing/browser/matchers.ts
+++ b/runtime/testing/browser/matchers.ts
@@ -43,7 +43,8 @@ let skyMatchers: jasmine.CustomMatcherFactories = {
 
         result.message = result.pass ?
           'Expected element\'s inner text not to be ' + expectedText :
-          'Expected element\'s inner text to be ' + expectedText;
+          `Expected element's inner text to be:\t${expectedText}\n` +
+          `Actual element's inner text was:    \t${actualText}`;
 
         return result;
       }


### PR DESCRIPTION
Old:
![image](https://user-images.githubusercontent.com/31487966/29891381-db5c90b4-8d98-11e7-9f0e-bcb06df73772.png)

New:
![image](https://user-images.githubusercontent.com/31487966/29891394-ed2e4a80-8d98-11e7-9dbe-2ea02bfa6486.png)

As a developer, I'd like to view what the actual value returned on failing errors so that I can more quickly see the differences between expected and actual.
