### PR TITLE
removed unneeded dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@angular/platform-browser-dynamic": "4.3.6",
     "@angular/router": "4.3.6",
     "@blackbaud/auth-client": "1.15.0",
-    "@blackbaud/help-client": "1.0.1",
     "@blackbaud/skyux-lib-help": "1.0.0",
     "@ngtools/webpack": "1.3.1",
     "@types/core-js": "0.9.41",


### PR DESCRIPTION
@Blackbaud-BobbyEarl having the `@blackbaud/help-client`  as a dependency of builder at the `1.0.1` version is causing an error preventing the widget from loading.  The `BBHelp` was renamed to `BBHelpClient` in `1.0.2` (probably should have been called `2.0.0`).