### PR TITLE
Using a build matrix to split coverage/e2e

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: node_js
 sudo: required
 dist: trusty
 
+env:
+  - TEST_COMMAND=coverage
+  - TEST_COMMAND=e2e
+
+script: "npm run lint && npm run $TEST_COMMAND"
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
This was a quick experiment in making the build slightly quicker.  It moves the coverage and e2e steps into separate "environments."  While not a huge impact, it does shave a couple minutes off the total "real" time needed.