### PR TITLE
removed /deep/ for page level classes

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -2,7 +2,6 @@
   visibility: hidden;
 }
 
-/deep/
 .sky-modal-body-full-page {
   // Hide the bb-Help-invoker when a full-page modal is present and the widget is closed.
   #bb-help-container.closed > #bb-help-invoker {


### PR DESCRIPTION
CSS override for help invoker not working with the `/deep/` modifier.  removed it to enable the bug fix for hiding the invoker with full page modals to function properly.