### PR TITLE
Disabling pulling down gecko for internal protractor tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "coverage:builder": "istanbul cover --report=html --dir=./coverage/builder ./node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=jasmine.json",
     "coverage:runtime": "node ./utils/cli-test.js dev-runtime",
     "coverage:src-app": "node ./utils/cli-test.js dev-src-app",
-    "e2e": "webdriver-manager update && protractor ./config/protractor/protractor-dev.conf.js",
+    "e2e": "webdriver-manager update --gecko false && protractor ./config/protractor/protractor-dev.conf.js",
     "jscs": "jscs cli config lib loader plugin src utils",
     "jshint": "jshint cli config lib loader plugin src utils",
     "lint": "npm run jshint && npm run jscs",


### PR DESCRIPTION
Other PRs are more likely to fail in Appveyor until this PR is merged in.