### PR TITLE
Reduced number of console logs for output keep alive

### DIFF
--- a/plugin/output-keep-alive/index.js
+++ b/plugin/output-keep-alive/index.js
@@ -11,39 +11,29 @@
  * @param {any} options
  */
 function OutputKeepAlivePlugin(options = {}) {
-  const printDot = () => process.stdout.write('.');
-
   this.apply = function (compiler) {
+    let done = false;
+
     if (!options.enabled) {
       return;
     }
 
-    // Set stdout to be synchronous, to avoid a memory heap issue:
-    // https://github.com/nodejs/node/issues/1741
-    // compiler.plugin('after-plugins', function () {
-    //   process.stdout._handle.setBlocking(true);
-    // });
+    const check = () => {
+      if (done) {
+        return;
+      }
 
-    compiler.plugin('compilation', function (compilation) {
-      printDot();
-
-      // More hooks found on the docs:
-      // https://webpack.js.org/api/compilation/
-      const hooks = [
-        // 'after-optimize-modules',
-        'build-module'
-      ];
-
-      hooks.forEach((hook) => {
-        compilation.plugin(hook, function () {
-          printDot();
-        });
+      setImmediate(() => {
+        process.stdout.write('.');
+        check();
       });
-    });
+    };
 
-    // compiler.plugin('done', function () {
-    //   process.stdout._handle.setBlocking(false);
-    // });
+    check();
+
+    compiler.plugin('done', function () {
+      done = true;
+    });
   };
 }
 

--- a/plugin/output-keep-alive/index.js
+++ b/plugin/output-keep-alive/index.js
@@ -11,28 +11,27 @@
  * @param {any} options
  */
 function OutputKeepAlivePlugin(options = {}) {
-  this.apply = function (compiler) {
-    let done = false;
+  const printDot = () => process.stdout.write('.');
 
+  this.apply = function (compiler) {
     if (!options.enabled) {
       return;
     }
 
-    const check = () => {
-      if (done) {
-        return;
-      }
+    compiler.plugin('compilation', function (compilation) {
+      printDot();
 
-      setImmediate(() => {
-        process.stdout.write('.');
-        check();
+      // More hooks found on the docs:
+      // https://webpack.js.org/api/compilation/
+      const hooks = [
+        'build-module'
+      ];
+
+      hooks.forEach((hook) => {
+        compilation.plugin(hook, function () {
+          printDot();
+        });
       });
-    };
-
-    check();
-
-    compiler.plugin('done', function () {
-      done = true;
     });
   };
 }

--- a/plugin/output-keep-alive/index.js
+++ b/plugin/output-keep-alive/index.js
@@ -20,9 +20,9 @@ function OutputKeepAlivePlugin(options = {}) {
 
     // Set stdout to be synchronous, to avoid a memory heap issue:
     // https://github.com/nodejs/node/issues/1741
-    compiler.plugin('after-plugins', function () {
-      process.stdout._handle.setBlocking(true);
-    });
+    // compiler.plugin('after-plugins', function () {
+    //   process.stdout._handle.setBlocking(true);
+    // });
 
     compiler.plugin('compilation', function (compilation) {
       printDot();
@@ -30,7 +30,7 @@ function OutputKeepAlivePlugin(options = {}) {
       // More hooks found on the docs:
       // https://webpack.js.org/api/compilation/
       const hooks = [
-        'after-optimize-modules',
+        // 'after-optimize-modules',
         'build-module'
       ];
 
@@ -41,9 +41,9 @@ function OutputKeepAlivePlugin(options = {}) {
       });
     });
 
-    compiler.plugin('done', function () {
-      process.stdout._handle.setBlocking(false);
-    });
+    // compiler.plugin('done', function () {
+    //   process.stdout._handle.setBlocking(false);
+    // });
   };
 }
 

--- a/plugin/output-keep-alive/index.js
+++ b/plugin/output-keep-alive/index.js
@@ -18,6 +18,12 @@ function OutputKeepAlivePlugin(options = {}) {
       return;
     }
 
+    // Set stdout to be synchronous, to avoid a memory heap issue:
+    // https://github.com/nodejs/node/issues/1741
+    compiler.plugin('after-plugins', function () {
+      process.stdout._handle.setBlocking(true);
+    });
+
     compiler.plugin('compilation', function (compilation) {
       printDot();
 
@@ -33,6 +39,10 @@ function OutputKeepAlivePlugin(options = {}) {
           printDot();
         });
       });
+    });
+
+    compiler.plugin('done', function () {
+      process.stdout._handle.setBlocking(false);
     });
   };
 }

--- a/plugin/output-keep-alive/index.js
+++ b/plugin/output-keep-alive/index.js
@@ -11,26 +11,16 @@
  * @param {any} options
  */
 function OutputKeepAlivePlugin(options = {}) {
-  const printDot = () => process.stdout.write('.');
-
   this.apply = function (compiler) {
     if (!options.enabled) {
       return;
     }
 
     compiler.plugin('compilation', function (compilation) {
-      printDot();
-
       // More hooks found on the docs:
       // https://webpack.js.org/api/compilation/
-      const hooks = [
-        'build-module'
-      ];
-
-      hooks.forEach((hook) => {
-        compilation.plugin(hook, function () {
-          printDot();
-        });
+      compilation.plugin('build-module', function () {
+        process.stdout.write('.');
       });
     });
   };

--- a/test/plugin-output-keep-alive.spec.js
+++ b/test/plugin-output-keep-alive.spec.js
@@ -41,9 +41,9 @@ describe('SKY UX plugin file processor', () => {
 
     plugin.apply(_mockCompiler);
 
-    expect(stdoutSpy.calls.count()).toEqual(3);
+    expect(stdoutSpy.calls.count()).toEqual(1);
     expect(_compilerHooksCalled).toEqual(['compilation']);
-    expect(_compilationHooksCalled).toEqual(['after-optimize-modules', 'build-module']);
+    expect(_compilationHooksCalled).toEqual(['build-module']);
   });
 
   it('should not output to the console if disabled', () => {


### PR DESCRIPTION
@Blackbaud-BobbyEarl: I believe `stdout` is causing the JavaScript heap issue because it's getting called several times in three different locations (and apparently, because stdout is asynchronous, it has a known problem of causing out-of-memory problems, especially in "blocking" contexts, such as loops). https://stackoverflow.com/questions/38085746/why-does-writing-to-stdout-in-a-hot-loop-cause-an-out-of-memory-shutdown

I reduced the number of calls to a single lifecycle hook, and the heap problem stopped (I'm also increasing the amount of memory available for the `skyux build` command, here: https://github.com/blackbaud/skyux2/pull/1285/files#diff-be484b29d7890da24734b568487a490bR8).