### PR TITLE
Build improvements

### DIFF
--- a/cli/build.js
+++ b/cli/build.js
@@ -15,7 +15,7 @@ const runCompiler = require('./utils/run-compiler');
 const tsLinter = require('./utils/ts-linter');
 
 function writeTSConfig() {
-  var config = {
+  const config = {
     'compilerOptions': {
       'target': 'es5',
       'module': 'es2015',
@@ -32,10 +32,19 @@ function writeTSConfig() {
       'lib': [
         'es2015',
         'dom'
+      ],
+      'types': [
+        'jasmine',
+        'node'
       ]
     },
     'files': [
       './app/app.module.ts'
+    ],
+    'exclude': [
+      'node_modules',
+      skyPagesConfigUtil.outPath('node_modules'),
+      '**/*.spec.ts'
     ],
     'compileOnSave': false,
     'buildOnSave': false,
@@ -45,7 +54,10 @@ function writeTSConfig() {
     }
   };
 
-  fs.writeJSONSync(skyPagesConfigUtil.spaPathTempSrc('tsconfig.json'), config);
+  fs.writeJSONSync(
+    skyPagesConfigUtil.spaPathTempSrc('tsconfig.json'),
+    config
+  );
 }
 
 function stageAot(skyPagesConfig, assetsBaseUrl, assetsRel) {
@@ -158,6 +170,7 @@ function buildCompiler(argv, skyPagesConfig, webpack, isAot) {
  * @param {*} isAot
  */
 function build(argv, skyPagesConfig, webpack) {
+
   const lintResult = tsLinter.lintSync();
   const isAot = skyPagesConfig &&
     skyPagesConfig.skyux &&

--- a/cli/build.js
+++ b/cli/build.js
@@ -32,22 +32,14 @@ function writeTSConfig() {
       'lib': [
         'es2015',
         'dom'
-      ],
-      'types': [
-        'jasmine',
-        'node'
       ]
     },
     'files': [
       './app/app.module.ts'
     ],
-    'exclude': [
-      '../../node_modules'
-    ],
     'compileOnSave': false,
     'buildOnSave': false,
     'angularCompilerOptions': {
-      'debug': true,
       'genDir': './ngfactory',
       'skipMetadataEmit': true
     }
@@ -166,7 +158,6 @@ function buildCompiler(argv, skyPagesConfig, webpack, isAot) {
  * @param {*} isAot
  */
 function build(argv, skyPagesConfig, webpack) {
-
   const lintResult = tsLinter.lintSync();
   const isAot = skyPagesConfig &&
     skyPagesConfig.skyux &&

--- a/config/webpack/build-aot.webpack.config.js
+++ b/config/webpack/build-aot.webpack.config.js
@@ -19,6 +19,10 @@ function getWebpackConfig(skyPagesConfig, argv) {
   let commonConfig = common.getWebpackConfig(skyPagesConfig, argv);
   commonConfig.entry = null;
 
+  // Resolves aren't needed for AoT and will only slow the build down:
+  commonConfig.resolveLoader = undefined;
+  commonConfig.resolve.modules = undefined;
+
   // Since the preloader is executed against the file system during an AoT build,
   // we need to remove it from the webpack config, otherwise it will get executed twice.
   commonConfig.module.rules = commonConfig.module.rules
@@ -58,6 +62,7 @@ function getWebpackConfig(skyPagesConfig, argv) {
 
       new UglifyJSPlugin({
         parallel: true,
+        exclude: /node_modules/,
         uglifyOptions: {
           compress: {
             warnings: false

--- a/config/webpack/build-aot.webpack.config.js
+++ b/config/webpack/build-aot.webpack.config.js
@@ -1,7 +1,6 @@
 /*jslint node: true */
 'use strict';
 
-const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 const ngtools = require('@ngtools/webpack');

--- a/config/webpack/build-public-library.webpack.config.js
+++ b/config/webpack/build-public-library.webpack.config.js
@@ -1,7 +1,6 @@
 /*jslint node: true */
 'use strict';
 
-const webpack = require('webpack');
 const ngcWebpack = require('ngc-webpack');
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 const skyPagesConfigUtil = require('../sky-pages/sky-pages.config');

--- a/config/webpack/build-public-library.webpack.config.js
+++ b/config/webpack/build-public-library.webpack.config.js
@@ -3,6 +3,7 @@
 
 const webpack = require('webpack');
 const ngcWebpack = require('ngc-webpack');
+const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 const skyPagesConfigUtil = require('../sky-pages/sky-pages.config');
 const ProcessExitCode = require('../../plugin/process-exit-code');
 
@@ -50,11 +51,17 @@ function getWebpackConfig(skyPagesConfig) {
         tsConfig: skyPagesConfigUtil.spaPathTemp('tsconfig.json')
       }),
 
-      new webpack.optimize.UglifyJsPlugin({
-        beautify: false,
-        comments: false,
-        compress: { warnings: false },
-        mangle: { screw_ie8: true, keep_fnames: true }
+      new UglifyJSPlugin({
+        parallel: true,
+        exclude: /node_modules/,
+        uglifyOptions: {
+          compress: {
+            warnings: false
+          },
+          mangle: {
+            keep_fnames: true
+          }
+        }
       }),
 
       // Webpack 2 behavior does not correctly return non-zero exit code.

--- a/config/webpack/build.webpack.config.js
+++ b/config/webpack/build.webpack.config.js
@@ -1,8 +1,8 @@
 /*jslint node: true */
 'use strict';
 
-const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
+const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 const SaveMetadata = require('../../plugin/save-metadata');
 
 /**
@@ -39,11 +39,18 @@ function getWebpackConfig(skyPagesConfig, argv) {
     },
     plugins: [
       SaveMetadata,
-      new webpack.optimize.UglifyJsPlugin({
-        beautify: false,
-        comments: false,
-        mangle: { screw_ie8: true, keep_fnames: true },
-        sourceMap: true
+
+      new UglifyJSPlugin({
+        parallel: true,
+        exclude: /node_modules/,
+        uglifyOptions: {
+          compress: {
+            warnings: false
+          },
+          mangle: {
+            keep_fnames: true
+          }
+        }
       })
     ]
   });

--- a/config/webpack/common.webpack.config.js
+++ b/config/webpack/common.webpack.config.js
@@ -27,15 +27,9 @@ function outPath() {
  * @returns {WebpackConfig} webpackConfig
  */
 function getWebpackConfig(skyPagesConfig, argv = {}) {
-  const resolves = [
-    process.cwd(),
-    spaPath('node_modules'),
-    outPath('node_modules')
-  ];
-
-  let alias = aliasBuilder.buildAliasList(skyPagesConfig);
-
+  const alias = aliasBuilder.buildAliasList(skyPagesConfig);
   const outConfigMode = skyPagesConfig && skyPagesConfig.skyux && skyPagesConfig.skyux.mode;
+
   let appPath;
 
   switch (outConfigMode) {
@@ -60,23 +54,23 @@ function getWebpackConfig(skyPagesConfig, argv = {}) {
       chunkFilename: '[id].chunk.js',
       path: spaPath('dist'),
     },
-    resolveLoader: {
-      modules: resolves
-    },
     resolve: {
-      alias: alias,
-      modules: resolves,
+      alias,
       extensions: [
         '.js',
         '.ts'
-      ]
+      ],
+      // Disable symlinks to increase performance:
+      // https://webpack.js.org/guides/build-performance/#resolving
+      symlinks: false
     },
     module: {
       rules: [
         {
           enforce: 'pre',
-          test: /runtime\/config\.ts$/,
-          loader: outPath('loader', 'sky-app-config')
+          test: /config\.ts$/,
+          loader: outPath('loader', 'sky-app-config'),
+          include: outPath('runtime')
         },
         {
           enforce: 'pre',
@@ -89,12 +83,13 @@ function getWebpackConfig(skyPagesConfig, argv = {}) {
         {
           enforce: 'pre',
           test: /sky-pages\.module\.ts$/,
-          loader: outPath('loader', 'sky-pages-module')
+          loader: outPath('loader', 'sky-pages-module'),
+          include: outPath('src', 'app')
         },
         {
           enforce: 'pre',
           loader: outPath('loader', 'sky-processor', 'preload'),
-          exclude: /node_modules/
+          include: spaPath('src')
         },
         {
           test: /\.s?css$/,

--- a/config/webpack/common.webpack.config.js
+++ b/config/webpack/common.webpack.config.js
@@ -93,8 +93,7 @@ function getWebpackConfig(skyPagesConfig, argv = {}) {
         {
           enforce: 'pre',
           test: /sky-pages\.module\.ts$/,
-          loader: outPath('loader', 'sky-pages-module'),
-          include: outPath('src', 'app')
+          loader: outPath('loader', 'sky-pages-module')
         },
         {
           enforce: 'pre',

--- a/config/webpack/common.webpack.config.js
+++ b/config/webpack/common.webpack.config.js
@@ -64,15 +64,17 @@ function getWebpackConfig(skyPagesConfig, argv = {}) {
       modules: resolves
     },
     resolve: {
-      alias,
+      alias: alias,
       modules: resolves,
       extensions: [
         '.js',
         '.ts'
       ],
+
       // Disable symlinks to increase performance:
       // https://webpack.js.org/guides/build-performance/#resolving
       symlinks: false
+
     },
     module: {
       rules: [
@@ -93,12 +95,14 @@ function getWebpackConfig(skyPagesConfig, argv = {}) {
         {
           enforce: 'pre',
           test: /sky-pages\.module\.ts$/,
-          loader: outPath('loader', 'sky-pages-module')
+          loader: outPath('loader', 'sky-pages-module'),
+          include: outPath('src', 'app'),
         },
         {
           enforce: 'pre',
           loader: outPath('loader', 'sky-processor', 'preload'),
-          include: spaPath('src')
+          include: spaPath('src'),
+          exclude: /node_modules/
         },
         {
           test: /\.s?css$/,

--- a/config/webpack/common.webpack.config.js
+++ b/config/webpack/common.webpack.config.js
@@ -33,9 +33,9 @@ function getWebpackConfig(skyPagesConfig, argv = {}) {
     outPath('node_modules')
   ];
 
-  const alias = aliasBuilder.buildAliasList(skyPagesConfig);
-  const outConfigMode = skyPagesConfig && skyPagesConfig.skyux && skyPagesConfig.skyux.mode;
+  let alias = aliasBuilder.buildAliasList(skyPagesConfig);
 
+  const outConfigMode = skyPagesConfig && skyPagesConfig.skyux && skyPagesConfig.skyux.mode;
   let appPath;
 
   switch (outConfigMode) {
@@ -64,23 +64,19 @@ function getWebpackConfig(skyPagesConfig, argv = {}) {
       modules: resolves
     },
     resolve: {
-      alias,
+      alias: alias,
       modules: resolves,
       extensions: [
         '.js',
         '.ts'
-      ],
-      // Disable symlinks to increase performance:
-      // https://webpack.js.org/guides/build-performance/#resolving
-      symlinks: false
+      ]
     },
     module: {
       rules: [
         {
           enforce: 'pre',
-          test: /config\.ts$/,
-          loader: outPath('loader', 'sky-app-config'),
-          include: outPath('runtime')
+          test: /runtime\/config\.ts$/,
+          loader: outPath('loader', 'sky-app-config')
         },
         {
           enforce: 'pre',
@@ -98,7 +94,7 @@ function getWebpackConfig(skyPagesConfig, argv = {}) {
         {
           enforce: 'pre',
           loader: outPath('loader', 'sky-processor', 'preload'),
-          include: spaPath('src')
+          exclude: /node_modules/
         },
         {
           test: /\.s?css$/,

--- a/config/webpack/common.webpack.config.js
+++ b/config/webpack/common.webpack.config.js
@@ -27,6 +27,12 @@ function outPath() {
  * @returns {WebpackConfig} webpackConfig
  */
 function getWebpackConfig(skyPagesConfig, argv = {}) {
+  const resolves = [
+    process.cwd(),
+    spaPath('node_modules'),
+    outPath('node_modules')
+  ];
+
   const alias = aliasBuilder.buildAliasList(skyPagesConfig);
   const outConfigMode = skyPagesConfig && skyPagesConfig.skyux && skyPagesConfig.skyux.mode;
 
@@ -54,8 +60,12 @@ function getWebpackConfig(skyPagesConfig, argv = {}) {
       chunkFilename: '[id].chunk.js',
       path: spaPath('dist'),
     },
+    resolveLoader: {
+      modules: resolves
+    },
     resolve: {
       alias,
+      modules: resolves,
       extensions: [
         '.js',
         '.ts'

--- a/config/webpack/common.webpack.config.js
+++ b/config/webpack/common.webpack.config.js
@@ -33,9 +33,9 @@ function getWebpackConfig(skyPagesConfig, argv = {}) {
     outPath('node_modules')
   ];
 
-  let alias = aliasBuilder.buildAliasList(skyPagesConfig);
-
+  const alias = aliasBuilder.buildAliasList(skyPagesConfig);
   const outConfigMode = skyPagesConfig && skyPagesConfig.skyux && skyPagesConfig.skyux.mode;
+
   let appPath;
 
   switch (outConfigMode) {
@@ -64,19 +64,23 @@ function getWebpackConfig(skyPagesConfig, argv = {}) {
       modules: resolves
     },
     resolve: {
-      alias: alias,
+      alias,
       modules: resolves,
       extensions: [
         '.js',
         '.ts'
-      ]
+      ],
+      // Disable symlinks to increase performance:
+      // https://webpack.js.org/guides/build-performance/#resolving
+      symlinks: false
     },
     module: {
       rules: [
         {
           enforce: 'pre',
-          test: /runtime\/config\.ts$/,
-          loader: outPath('loader', 'sky-app-config')
+          test: /config\.ts$/,
+          loader: outPath('loader', 'sky-app-config'),
+          include: outPath('runtime')
         },
         {
           enforce: 'pre',
@@ -94,7 +98,7 @@ function getWebpackConfig(skyPagesConfig, argv = {}) {
         {
           enforce: 'pre',
           loader: outPath('loader', 'sky-processor', 'preload'),
-          exclude: /node_modules/
+          include: spaPath('src')
         },
         {
           test: /\.s?css$/,

--- a/e2e/skyux-build-aot.e2e-spec.js
+++ b/e2e/skyux-build-aot.e2e-spec.js
@@ -4,14 +4,26 @@ const common = require('./shared/common');
 const tests = require('./shared/tests');
 
 function prepareBuild() {
-  const opts = { mode: 'easy', name: 'dist', compileMode: 'aot' };
-  return common.prepareBuild(opts)
+  const opts = {
+    mode: 'easy',
+    name: 'dist',
+    compileMode: 'aot'
+  };
+
+  return common
+    .prepareBuild(opts)
     .catch(console.error);
 }
 
 describe('skyux build aot', () => {
   describe('w/base template', () => {
-    beforeAll((done) => prepareBuild().then(done));
+    beforeAll((done) => {
+      prepareBuild()
+        .then(() => {
+          console.info('Protractor build complete!');
+          done();
+        });
+    });
 
     it('should have exitCode 0', tests.verifyExitCode);
 

--- a/lib/sky-pages-module-generator.js
+++ b/lib/sky-pages-module-generator.js
@@ -68,7 +68,7 @@ function getSource(skyAppConfig) {
   ];
 
   let nodeModuleImports = [
-    `import { Component, NgModule, OnInit } from '@angular/core';`,
+    `import { Component, NgModule, OnDestroy, OnInit } from '@angular/core';`,
     `import { CommonModule } from '@angular/common';`,
     `import { HttpModule } from '@angular/http';`,
     `import { FormsModule, ReactiveFormsModule } from '@angular/forms';`,

--- a/lib/sky-pages-module-generator.js
+++ b/lib/sky-pages-module-generator.js
@@ -68,12 +68,7 @@ function getSource(skyAppConfig) {
   ];
 
   let nodeModuleImports = [
-    `import {
-      Component,
-      NgModule,
-      OnInit,
-      OnDestroy
-    } from '@angular/core';`,
+    `import { Component, NgModule, OnInit } from '@angular/core';`,
     `import { CommonModule } from '@angular/common';`,
     `import { HttpModule } from '@angular/http';`,
     `import { FormsModule, ReactiveFormsModule } from '@angular/forms';`,
@@ -143,22 +138,30 @@ BBAuth.mock = true;
 
   let moduleSource =
 `${useMockAuth}
+
 ${nodeModuleImports.join('\n')}
+
 import '${skyAppConfig.runtime.skyPagesOutAlias}/src/main';
 import { SkyModule } from '${skyAppConfig.runtime.skyuxPathAlias}/core';
 import {
   AppExtrasModule
 } from '${skyAppConfig.runtime.skyPagesOutAlias}/src/app/app-extras.module';
 import { ${runtimeImports.join(', ')} } from '${skyAppConfig.runtime.runtimeAlias}';
+
 import { SkyAppAssetsService } from '${skyAppConfig.runtime.runtimeAlias}/assets.service';
+
 import {
   SkyAppResourcesService
 } from '${skyAppConfig.runtime.runtimeAlias}/i18n/resources.service';
+
 import {
   SkyAppResourcesPipe
 } from '${skyAppConfig.runtime.runtimeAlias}/i18n/resources.pipe';
+
 ${assetsGenerator.getSource()}
+
 ${routes.imports.join('\n')}
+
 export function SkyAppConfigFactory(windowRef: SkyAppWindowRef): any {
   const config: any = ${skyAppConfigAsString};
   config.runtime.params = new SkyAppRuntimeConfigParams(
@@ -167,15 +170,20 @@ export function SkyAppConfigFactory(windowRef: SkyAppWindowRef): any {
   );
   return config;
 }
+
 // Setting skyux config as static property exclusively for Bootstrapper
 SkyAppBootstrapper.config = ${JSON.stringify(skyAppConfig.skyux)};
+
 ${components.imports}
 ${routes.definitions}
+
 // Routes need to be defined after their corresponding components
 const appRoutingProviders: any[] = [${routes.providers}];
 const routes: Routes = ${routes.declarations};
 const routing = RouterModule.forRoot(routes, { useHash: ${useHashRouting} });
+
 ${enableProdMode}
+
 @NgModule({
   declarations: [
     ${names.join(',\n' + codegen.indent(2))}

--- a/lib/sky-pages-module-generator.js
+++ b/lib/sky-pages-module-generator.js
@@ -67,26 +67,15 @@ function getSource(skyAppConfig) {
     'SkyAppViewportService'
   ];
 
-  if (skyAppConfig.skyux.auth) {
-    runtimeImports.push(`SkyAuthHttp`);
-    runtimeProviders.push(`{
-      provide: SkyAuthHttp,
-      useClass: SkyAuthHttp,
-      deps: [XHRBackend, RequestOptions, SkyAuthTokenProvider, SkyAppConfig]
-    }`);
-  }
-
   let nodeModuleImports = [
     `import {
       Component,
-      Inject,
       NgModule,
       OnInit,
-      OnDestroy,
-      OpaqueToken
+      OnDestroy
     } from '@angular/core';`,
     `import { CommonModule } from '@angular/common';`,
-    `import { HttpModule, XHRBackend, RequestOptions } from '@angular/http';`,
+    `import { HttpModule } from '@angular/http';`,
     `import { FormsModule, ReactiveFormsModule } from '@angular/forms';`,
     `import { ActivatedRoute, RouterModule, Routes } from '@angular/router';`,
     `import { Subscription } from 'rxjs/Subscription';`
@@ -104,6 +93,16 @@ function getSource(skyAppConfig) {
     'SkyModule',
     'AppExtrasModule'
   ];
+
+  if (skyAppConfig.skyux.auth) {
+    nodeModuleImports.push(`import { XHRBackend, RequestOptions } from '@angular/http';`);
+    runtimeImports.push(`SkyAuthHttp`);
+    runtimeProviders.push(`{
+      provide: SkyAuthHttp,
+      useClass: SkyAuthHttp,
+      deps: [XHRBackend, RequestOptions, SkyAuthTokenProvider, SkyAppConfig]
+    }`);
+  }
 
   if (skyAppConfig.skyux.help) {
     nodeModuleImports.push(`import { BBHelpModule } from '@blackbaud/skyux-lib-help';`);
@@ -144,30 +143,22 @@ BBAuth.mock = true;
 
   let moduleSource =
 `${useMockAuth}
-
 ${nodeModuleImports.join('\n')}
-
 import '${skyAppConfig.runtime.skyPagesOutAlias}/src/main';
 import { SkyModule } from '${skyAppConfig.runtime.skyuxPathAlias}/core';
 import {
   AppExtrasModule
 } from '${skyAppConfig.runtime.skyPagesOutAlias}/src/app/app-extras.module';
 import { ${runtimeImports.join(', ')} } from '${skyAppConfig.runtime.runtimeAlias}';
-
 import { SkyAppAssetsService } from '${skyAppConfig.runtime.runtimeAlias}/assets.service';
-
 import {
   SkyAppResourcesService
 } from '${skyAppConfig.runtime.runtimeAlias}/i18n/resources.service';
-
 import {
   SkyAppResourcesPipe
 } from '${skyAppConfig.runtime.runtimeAlias}/i18n/resources.pipe';
-
 ${assetsGenerator.getSource()}
-
 ${routes.imports.join('\n')}
-
 export function SkyAppConfigFactory(windowRef: SkyAppWindowRef): any {
   const config: any = ${skyAppConfigAsString};
   config.runtime.params = new SkyAppRuntimeConfigParams(
@@ -176,20 +167,15 @@ export function SkyAppConfigFactory(windowRef: SkyAppWindowRef): any {
   );
   return config;
 }
-
 // Setting skyux config as static property exclusively for Bootstrapper
 SkyAppBootstrapper.config = ${JSON.stringify(skyAppConfig.skyux)};
-
 ${components.imports}
 ${routes.definitions}
-
 // Routes need to be defined after their corresponding components
 const appRoutingProviders: any[] = [${routes.providers}];
 const routes: Routes = ${routes.declarations};
 const routing = RouterModule.forRoot(routes, { useHash: ${useHashRouting} });
-
 ${enableProdMode}
-
 @NgModule({
   declarations: [
     ${names.join(',\n' + codegen.indent(2))}

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "jshint": "2.9.4",
     "mock-require": "2.0.2",
     "proxyquire": "1.8.0",
-    "rimraf": "2.6.1"
+    "rimraf": "2.6.1",
+    "uglifyjs-webpack-plugin": "1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "ts-node": "3.0.4",
     "tslint": "5.2.0",
     "typescript": "2.3.2",
+    "uglifyjs-webpack-plugin": "1.0.1",
     "web-animations-js": "2.2.5",
     "webpack": "2.5.1",
     "webpack-dev-server": "2.4.5",
@@ -110,7 +111,6 @@
     "jshint": "2.9.4",
     "mock-require": "2.0.2",
     "proxyquire": "1.8.0",
-    "rimraf": "2.6.1",
-    "uglifyjs-webpack-plugin": "1.0.1"
+    "rimraf": "2.6.1"
   }
 }

--- a/test/config-webpack-build-aot.spec.js
+++ b/test/config-webpack-build-aot.spec.js
@@ -29,7 +29,12 @@ describe('config webpack build-aot', () => {
   it('should merge the common webpack config with overrides', () => {
     const f = '../config/webpack/common.webpack.config';
     mock(f, {
-      getWebpackConfig: () => ({ module: { rules: [] } })
+      getWebpackConfig: () => ({
+        module: {
+          rules: []
+        },
+        resolve: { }
+      })
     });
 
     const lib = require('../config/webpack/build-aot.webpack.config');
@@ -56,7 +61,12 @@ describe('config webpack build-aot', () => {
   it('should use the AoT entry module', () => {
     const f = '../config/webpack/common.webpack.config';
     mock(f, {
-      getWebpackConfig: () => ({ module: { rules: [] } })
+      getWebpackConfig: () => ({
+        module: {
+          rules: []
+        },
+        resolve: { }
+      })
     });
 
     const lib = require('../config/webpack/build-aot.webpack.config');
@@ -207,7 +217,8 @@ describe('config webpack build-aot', () => {
               loader: loaderName
             }
           ]
-        }
+        },
+        resolve: { }
       })
     });
 
@@ -248,7 +259,8 @@ describe('config webpack build-aot', () => {
               loader: loaderName
             }
           ]
-        }
+        },
+        resolve: { }
       })
     });
 
@@ -273,6 +285,33 @@ describe('config webpack build-aot', () => {
 
     expect(found).toEqual(false);
     expect(config.module.rules.length).toEqual(2);
+  });
+
+  it('should remove resolves', () => {
+    const f = '../config/webpack/common.webpack.config';
+    const loaderName = '\\sky-processor\\';
+    mock(f, {
+      getWebpackConfig: () => ({
+        module: {
+          rules: []
+        },
+        resolveLoader: {},
+        resolve: {
+          modules: {}
+        }
+      })
+    });
+
+    const lib = require('../config/webpack/build-aot.webpack.config');
+
+    const skyPagesConfig = {
+      runtime: runtimeUtils.getDefaultRuntime(),
+      skyux: {}
+    };
+
+    const config = lib.getWebpackConfig(skyPagesConfig);
+    expect(config.resolveLoader).toBeUndefined();
+    expect(config.resolve.modules).toBeUndefined();
   });
 
 });


### PR DESCRIPTION
- Using isolated UglifyJSPlugin, which includes parallelization, https://github.com/webpack-contrib/uglifyjs-webpack-plugin/releases/tag/v1.0.0. (The aliased plugin provided by Webpack only includes version `0.4.x`.) Turns out that minifying the source code takes about 25% of the total build time.
- Targeted folders for various loaders
- Disabled sourcemaps for production. Do we really need them? https://webpack.js.org/guides/build-performance/#source-maps
- Disabled type checking for `ngtools` plugin.
- Removed some imports when auth is set to false.

SKY UX is using these changes with success: https://github.com/blackbaud/skyux2/pull/1294

**Before:**

<img width="322" alt="screen shot 2017-11-15 at 12 27 59 pm" src="https://user-images.githubusercontent.com/12497062/32853121-44c34664-ca08-11e7-87c7-1a18c76e3687.png">

**After:**

<img width="314" alt="screen shot 2017-11-16 at 10 02 47 pm" src="https://user-images.githubusercontent.com/12497062/32927331-fc3902f4-cb19-11e7-982c-a6eb5bba6e46.png">


