### PR TITLE
Feature localize help

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -28,7 +28,7 @@ import {
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
-
+  let mockSkyuxHost: any;
   let comp: AppComponent;
   let fixture: ComponentFixture<AppComponent>;
   let parseParams: any;
@@ -88,6 +88,7 @@ describe('AppComponent', () => {
         useValue: {
           nativeWindow: {
             location: location,
+            SKYUX_HOST: mockSkyuxHost,
             scroll: () => scrollCalled = true
           }
         }
@@ -514,6 +515,55 @@ describe('AppComponent', () => {
     setup(skyAppConfig).then(() => {
       fixture.detectChanges();
       expect(spyHelp).not.toHaveBeenCalledWith(skyAppConfig.skyux.help);
+      expect(spyHelp).toHaveBeenCalledWith(expectedCall);
+    });
+  }));
+
+  it('should assign help config locale key if none exist and host exposes the browser language', async(() => {
+    let spyHelp = spyOn(mockHelpInitService, 'load');
+
+    skyAppConfig.runtime.params.has = (key: any) => key === false;
+
+    mockSkyuxHost = {
+      acceptLanguage: 'fr-ca'
+    };
+    const expectedCall = { productId: 'test-config', extends: 'bb-help', locale: mockSkyuxHost.acceptLanguage };
+    skyAppConfig.skyux.help = { productId: 'test-config', extends: 'bb-help' };
+
+    setup(skyAppConfig).then(() => {
+      fixture.detectChanges();
+      expect(spyHelp).not.toHaveBeenCalledWith(skyAppConfig.skyux.help);
+      expect(spyHelp).toHaveBeenCalledWith(expectedCall);
+    });
+  }));
+
+  it('should fallback to \'\' for the locale if SKYUX_HOST.acceptLanguage does not exist', async(() => {
+    let spyHelp = spyOn(mockHelpInitService, 'load');
+
+    skyAppConfig.runtime.params.has = (key: any) => key === false;
+
+    mockSkyuxHost = { };
+    const expectedCall = { productId: 'test-config', extends: 'bb-help', locale: '' };
+    skyAppConfig.skyux.help = { productId: 'test-config', extends: 'bb-help' };
+
+    setup(skyAppConfig).then(() => {
+      fixture.detectChanges();
+      expect(spyHelp).not.toHaveBeenCalledWith(skyAppConfig.skyux.help);
+      expect(spyHelp).toHaveBeenCalledWith(expectedCall);
+    });
+  }));
+
+  it('should not override a locale that has been passed into the config', async(() => {
+    let spyHelp = spyOn(mockHelpInitService, 'load');
+    mockSkyuxHost = {
+      acceptLanguage: 'fr-ca'
+    };
+    const expectedCall = { productId: 'test-config', extends: 'bb-help', locale: 'en-ga' };
+    skyAppConfig.skyux.help = { productId: 'test-config', extends: 'bb-help', locale: 'en-ga' };
+
+    setup(skyAppConfig).then(() => {
+      fixture.detectChanges();
+      expect(spyHelp).toHaveBeenCalledWith(skyAppConfig.skyux.help);
       expect(spyHelp).toHaveBeenCalledWith(expectedCall);
     });
   }));

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -217,6 +217,11 @@ export class AppComponent implements OnInit {
         helpConfig.extends = this.config.runtime.params.get('svcid');
       }
 
+      if ((this.windowRef.nativeWindow as any).SKYUX_HOST && !helpConfig.locale) {
+        let browserLanguages = (this.windowRef.nativeWindow as any).SKYUX_HOST.acceptLanguage || '';
+        helpConfig.locale = browserLanguages.split(',')[0];
+      }
+
       this.helpInitService.load(helpConfig);
     }
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -215,6 +215,7 @@ export class AppComponent implements OnInit {
   private initShellComponents() {
     const omnibarConfig = this.config.skyux.omnibar;
     const helpConfig = this.config.skyux.help;
+    const skyuxHost = (this.windowRef.nativeWindow as any).SKYUX_HOST;
 
     const loadOmnibar = (args?: SkyAppOmnibarReadyArgs) => {
       this.setParamsFromQS(omnibarConfig);
@@ -257,8 +258,8 @@ export class AppComponent implements OnInit {
         helpConfig.extends = this.config.runtime.params.get('svcid');
       }
 
-      if ((this.windowRef.nativeWindow as any).SKYUX_HOST && !helpConfig.locale) {
-        let browserLanguages = (this.windowRef.nativeWindow as any).SKYUX_HOST.acceptLanguage || '';
+      if (skyuxHost && !helpConfig.locale) {
+        let browserLanguages = skyuxHost.acceptLanguage || '';
         helpConfig.locale = browserLanguages.split(',')[0];
       }
 


### PR DESCRIPTION
Accessing the `SKYUX_HOST` if it exists from HOST, and grabbing the `acceptLanguage` so the Help config will be updated to use the locale.