### PR TITLE
Enable hmr

### DIFF
--- a/cli/serve.js
+++ b/cli/serve.js
@@ -70,6 +70,7 @@ function serve(argv, skyPagesConfig, webpack, WebpackDevServer) {
 
       // This is required in order to not have HMR requests routed to host.
       config.output.publicPath = `${localUrl}${config.devServer.publicPath}`;
+      logger.info('Using hot module replacement.');
     }
 
     const compiler = webpack(config);

--- a/cli/serve.js
+++ b/cli/serve.js
@@ -56,10 +56,20 @@ function serve(argv, skyPagesConfig, webpack, WebpackDevServer) {
 
     /* istanbul ignore else */
     if (config.devServer.inline) {
-      const hot = `webpack-dev-server/client?${localUrl}`;
+      const inline = `webpack-dev-server/client?${localUrl}`;
+      Object.keys(config.entry).forEach((entry) => {
+        config.entry[entry].unshift(inline);
+      });
+    }
+
+    if (config.devServer.hot) {
+      const hot = `webpack/hot/only-dev-server`;
       Object.keys(config.entry).forEach((entry) => {
         config.entry[entry].unshift(hot);
       });
+
+      // This is required in order to not have HMR requests routed to host.
+      config.output.publicPath = `${localUrl}${config.devServer.publicPath}`;
     }
 
     const compiler = webpack(config);

--- a/config/webpack/serve.webpack.config.js
+++ b/config/webpack/serve.webpack.config.js
@@ -6,6 +6,7 @@ const path = require('path');
 const webpackMerge = require('webpack-merge');
 const NamedModulesPlugin = require('webpack/lib/NamedModulesPlugin');
 const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
+const HotModuleReplacementPlugin = require('webpack/lib/HotModuleReplacementPlugin');
 
 const skyPagesConfigUtil = require('../sky-pages/sky-pages.config');
 const logger = require('../../utils/logger');
@@ -64,6 +65,7 @@ function getWebpackConfig(argv, skyPagesConfig) {
     devServer: {
       compress: true,
       inline: true,
+      hot: argv.hmr,
       contentBase: path.join(process.cwd(), 'src', 'app'),
       headers: {
         'Access-Control-Allow-Origin': '*'
@@ -85,7 +87,8 @@ function getWebpackConfig(argv, skyPagesConfig) {
       new LoaderOptionsPlugin({
         context: __dirname,
         debug: true
-      })
+      }),
+      new HotModuleReplacementPlugin()
     ]
   });
 }

--- a/src/main-internal.ts
+++ b/src/main-internal.ts
@@ -1,7 +1,13 @@
+declare var module: any;
+
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 
 import { SkyAppBootstrapper } from '../runtime/bootstrapper';
+
+if (module.hot) {
+  module.hot.accept();
+}
 
 SkyAppBootstrapper.processBootstrapConfig().then(() => {
   platformBrowserDynamic().bootstrapModule(AppModule);

--- a/test/cli-serve.spec.js
+++ b/test/cli-serve.spec.js
@@ -61,12 +61,13 @@ describe('cli serve', () => {
     }, webpackDevServer);
   });
 
-  it('should prepent hrm url to entries if devServer.hot is set', (done) => {
+  it('should prepend hrm url to entries if devServer.hot is set', (done) => {
     const publicPath = '/public-path';
     const url = 'my-url';
     const port = 1234;
 
     const f = '../config/webpack/serve.webpack.config';
+    spyOn(logger, 'info');
     mock(f, {
       getWebpackConfig: () => ({
         output: {},
@@ -90,6 +91,7 @@ describe('cli serve', () => {
     require('../cli/serve')({}, {}, (config) => {
       expect(config.entry.test[0]).toEqual('webpack/hot/only-dev-server');
       expect(config.output.publicPath).toEqual(`https://localhost:${port}${publicPath}`);
+      expect(logger.info).toHaveBeenCalledWith('Using hot module replacement.');
       mock.stop(f);
       done();
     }, webpackDevServer);

--- a/test/cli-serve.spec.js
+++ b/test/cli-serve.spec.js
@@ -61,6 +61,40 @@ describe('cli serve', () => {
     }, webpackDevServer);
   });
 
+  it('should prepent hrm url to entries if devServer.hot is set', (done) => {
+    const publicPath = '/public-path';
+    const url = 'my-url';
+    const port = 1234;
+
+    const f = '../config/webpack/serve.webpack.config';
+    mock(f, {
+      getWebpackConfig: () => ({
+        output: {},
+        entry: {
+          'test': [url]
+        },
+        devServer: {
+          hot: true,
+          publicPath: publicPath,
+          port: port
+        }
+      })
+    });
+
+    function webpackDevServer() {
+      return {
+        listen: () => {}
+      };
+    }
+
+    require('../cli/serve')({}, {}, (config) => {
+      expect(config.entry.test[0]).toEqual('webpack/hot/only-dev-server');
+      expect(config.output.publicPath).toEqual(`https://localhost:${port}${publicPath}`);
+      mock.stop(f);
+      done();
+    }, webpackDevServer);
+  });
+
   it('should handle a webpackDevServer error', (done) => {
     const err = 'custom-error1';
     const f = '../config/webpack/serve.webpack.config';


### PR DESCRIPTION
Investigating solving https://github.com/blackbaud/skyux2/issues/406.  To test, install this branch and run `skyux serve --hmr` . We could also evaluate this being the default behavior.  Whichever is decided, a docs change would be necessary.