### PR TITLE
switch rxjs dependency to use the compatibilty flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "raw-loader": "0.5.1",
     "reflect-metadata": "0.1.10",
     "remap-istanbul": "0.9.5",
-    "rxjs": "^5.4.3",
+    "rxjs": "^5.5.6",
     "sass-loader": "6.0.5",
     "selenium-standalone": "6.4.1",
     "selenium-webdriver": "3.5.0",


### PR DESCRIPTION
I need the `rxjs` dependency to use the compatibility flag.  This resolves a conflict with a third-party library which also has a dependency on `rxjs`.