### PR TITLE
Contribute `skyAppLinkExternal`

### DIFF
--- a/lib/sky-pages-module-generator.js
+++ b/lib/sky-pages-module-generator.js
@@ -28,6 +28,7 @@ function getSource(skyAppConfig) {
   // These should also be defined in runtimeImports
   const runtimeComponents = [
     'SkyAppLinkDirective',
+    'SkyAppLinkExternalDirective',
     'SkyAppResourcesPipe'
   ];
 
@@ -44,6 +45,7 @@ function getSource(skyAppConfig) {
     'SkyAppWindowRef',
     'SkyAuthTokenProvider',
     'SkyAppLinkDirective',
+    'SkyAppLinkExternalDirective',
     'SkyAppStyleLoader',
     'SkyAppViewportService'
   ];

--- a/runtime/directives/index.ts
+++ b/runtime/directives/index.ts
@@ -1,2 +1,2 @@
-export * from "./sky-app-link.directive";
-export * from "./sky-app-link-external.directive";
+export * from './sky-app-link.directive';
+export * from './sky-app-link-external.directive';

--- a/runtime/directives/index.ts
+++ b/runtime/directives/index.ts
@@ -1,1 +1,2 @@
-export * from './sky-app-link.directive';
+export * from "./sky-app-link.directive";
+export * from "./sky-app-link-external.directive";

--- a/runtime/directives/sky-app-link-external.directive.spec.ts
+++ b/runtime/directives/sky-app-link-external.directive.spec.ts
@@ -1,8 +1,8 @@
 import { Component, DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { By } from '@angular/platform-browser';
 
-// import { RouterLinkWithHref } from '@angular/router';
 import { SkyAppConfig } from '../config';
 import { SkyAppLinkExternalDirective } from './sky-app-link-external.directive';
 import { SkyAppWindowRef } from '../window-ref';
@@ -14,24 +14,30 @@ class SkyAppLinkExternalTestComponent {
   public static readonly testUrl: string = 'testUrl';
 }
 
-describe('fSkyAppLink Directive', () => {
+describe('SkyAppLinkExternal Directive', () => {
   let component: SkyAppLinkExternalTestComponent;
   let fixture: ComponentFixture<SkyAppLinkExternalTestComponent>;
   let debugElement: DebugElement;
 
-  const mockWindowService = {
-    getWindow(): any {
+  class MockWindowService {
+    public get nativeWindow() {
       return {
-        setTimeout: (cb: Function) => cb()
+        window: {
+          name: ''
+        }
       };
     }
-  };
+  }
+
+  let mockWindowService = new MockWindowService();
 
   function setup(params: any) {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
       declarations: [SkyAppLinkExternalDirective, SkyAppLinkExternalTestComponent],
-      imports: [],
+      imports: [
+        RouterTestingModule
+      ],
       providers: [
         {
           provide: SkyAppConfig,

--- a/runtime/directives/sky-app-link-external.directive.spec.ts
+++ b/runtime/directives/sky-app-link-external.directive.spec.ts
@@ -1,0 +1,76 @@
+import { Component, DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+// import { RouterLinkWithHref } from '@angular/router';
+import { SkyAppConfig } from '../config';
+import { SkyAppLinkExternalDirective } from './sky-app-link-external.directive';
+import { SkyAppWindowRef } from '../window-ref';
+
+@Component({
+  template: `<a skyAppLinkExternal='test'>Test</a>`
+})
+class SkyAppLinkExternalTestComponent {
+  public static readonly testUrl: string = 'testUrl';
+}
+
+describe('fSkyAppLink Directive', () => {
+  let component: SkyAppLinkExternalTestComponent;
+  let fixture: ComponentFixture<SkyAppLinkExternalTestComponent>;
+  let debugElement: DebugElement;
+
+  const mockWindowService = {
+    getWindow(): any {
+      return {
+        setTimeout: (cb: Function) => cb()
+      };
+    }
+  };
+
+  function setup(params: any) {
+    TestBed.configureTestingModule({
+      schemas: [NO_ERRORS_SCHEMA],
+      declarations: [SkyAppLinkExternalDirective, SkyAppLinkExternalTestComponent],
+      imports: [],
+      providers: [
+        {
+          provide: SkyAppConfig,
+          useValue: {
+            runtime: {
+              params: {
+                getAll: () => params
+              }
+            },
+            skyux: {
+              host: {
+                url: SkyAppLinkExternalTestComponent.testUrl
+              }
+            }
+          }
+        },
+        { provide: SkyAppWindowRef, useValue: mockWindowService }
+      ]
+    });
+
+    fixture = TestBed.createComponent(SkyAppLinkExternalTestComponent);
+    component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+
+    fixture.detectChanges(); // initial binding
+  }
+
+  it('should set href without any queryParams', () => {
+    setup({});
+    const directive = debugElement.query(By.directive(SkyAppLinkExternalDirective));
+    expect(directive.attributes['skyAppLinkExternal']).toEqual('test');
+  });
+
+  it('should set href with queryParams', () => {
+    setup({
+      asdf: 123,
+      jkl: 'mno'
+    });
+    const directive = debugElement.query(By.directive(SkyAppLinkExternalDirective));
+    expect(directive.attributes['skyAppLinkExternal']).toEqual('test');
+  });
+});

--- a/runtime/directives/sky-app-link-external.directive.ts
+++ b/runtime/directives/sky-app-link-external.directive.ts
@@ -9,9 +9,23 @@ import { ActivatedRoute, Router, RouterLinkWithHref } from '@angular/router';
 })
 export class SkyAppLinkExternalDirective extends RouterLinkWithHref {
 
+  private _queryParams: { [k: string]: any };
+
   @Input()
   set skyAppLinkExternal(commands: any[] | string) {
     this.routerLink = commands;
+  }
+
+  @Input()
+  set queryParams(params: { [k: string]: any }) {
+    this._queryParams = Object.assign(params, this.skyAppConfig.runtime.params.getAll());
+  }
+
+  get queryParams() {
+    if (!this._queryParams) {
+      this._queryParams = Object.assign({}, this.skyAppConfig.runtime.params.getAll());
+    }
+    return this._queryParams;
   }
 
   constructor(
@@ -22,8 +36,6 @@ export class SkyAppLinkExternalDirective extends RouterLinkWithHref {
     private window: SkyAppWindowRef
   ) {
     super(router, route, new PathLocationStrategy(platformLocation, skyAppConfig.skyux.host.url));
-    this.queryParamsHandling = 'merge';
-    this.queryParams = this.skyAppConfig.runtime.params.getAll();
     if (this.window.nativeWindow.window.name && this.window.nativeWindow.window.name !== '') {
       this.target = this.window.nativeWindow.window.name;
     } else {

--- a/runtime/directives/sky-app-link-external.directive.ts
+++ b/runtime/directives/sky-app-link-external.directive.ts
@@ -1,36 +1,29 @@
-import { Directive, Input, HostListener, OnInit } from '@angular/core';
+import { Directive, Input } from '@angular/core';
+import { PathLocationStrategy, PlatformLocation } from '@angular/common';
 import { SkyAppWindowRef } from '../window-ref';
-import { SkyAppConfig } from '@blackbaud/skyux-builder/runtime';
-import { HttpParams } from '@angular/common/http';
+import { SkyAppConfig } from '../config';
+import { ActivatedRoute, Router, RouterLinkWithHref } from '@angular/router';
 
 @Directive({
   selector: '[skyAppLinkExternal]'
 })
-export class SkyAppLinkExternalDirective implements OnInit {
-  @Input() private skyAppLinkExternal: string;
-  private externalSPAUrl: string;
+export class SkyAppLinkExternalDirective extends RouterLinkWithHref {
 
-  constructor(
-    private skyAppConfig: SkyAppConfig,
-    private window: SkyAppWindowRef
-  ) { }
-
-  public ngOnInit() {
-    const queryParams: any = this.skyAppConfig.runtime.params.getAll();
-    const urlParts = this.skyAppLinkExternal.split('?');
-
-    let params = new HttpParams({ fromString: urlParts[1] });
-    for (const key in queryParams) {
-      if (queryParams.hasOwnProperty(key)) {
-        params = params.append(key, queryParams[key]);
-      }
-    }
-
-    this.externalSPAUrl = `${this.skyAppConfig.skyux.host.url}${urlParts[0]}?${params.toString()}`;
+  @Input()
+  set skyAppLinkExternal(commands: any[] | string) {
+    this.routerLink = commands;
   }
 
-  @HostListener('click', ['$event'])
-  public onClick(event: MouseEvent) {
-    this.window.nativeWindow.location.href = this.externalSPAUrl;
+  constructor(
+    router: Router,
+    route: ActivatedRoute,
+    platformLocation: PlatformLocation,
+    private skyAppConfig: SkyAppConfig,
+    private window: SkyAppWindowRef
+  ) {
+    super(router, route, new PathLocationStrategy(platformLocation, skyAppConfig.skyux.host.url));
+    this.queryParamsHandling = 'merge';
+    this.queryParams = this.skyAppConfig.runtime.params.getAll();
+    this.target = this.window.nativeWindow.window.name || '_top';
   }
 }

--- a/runtime/directives/sky-app-link-external.directive.ts
+++ b/runtime/directives/sky-app-link-external.directive.ts
@@ -1,0 +1,31 @@
+import { Directive, Input, HostListener } from "@angular/core";
+import { SkyAppWindowRef } from "../window-ref";
+import { SkyAppConfig } from "../config";
+import { HttpParams } from '@angular/common/http';
+
+@Directive({
+  selector: "[skyAppLinkExternal]"
+})
+export class SkyAppLinkExternalDirective {
+  @Input() skyAppLinkExternal: string;
+
+  constructor(
+    private skyAppConfig: SkyAppConfig,
+    private window: SkyAppWindowRef
+  ) { }
+
+  @HostListener("click", ["$event"])
+  public onClick(event: MouseEvent) {
+    const queryParams: any = this.skyAppConfig.runtime.params.getAll();
+    const urlParts = this.skyAppLinkExternal.split('?');
+
+    let params = new HttpParams({ fromString: urlParts[1] })
+    for (const key in queryParams) {
+      if (queryParams.hasOwnProperty(key)) {
+        params = params.append(key, queryParams[key]);
+      }
+    }
+
+    this.window.nativeWindow.location.href = `${this.skyAppConfig.skyux.host.url}${urlParts[0]}?${params.toString()}`;
+  }
+}

--- a/runtime/directives/sky-app-link-external.directive.ts
+++ b/runtime/directives/sky-app-link-external.directive.ts
@@ -24,6 +24,10 @@ export class SkyAppLinkExternalDirective extends RouterLinkWithHref {
     super(router, route, new PathLocationStrategy(platformLocation, skyAppConfig.skyux.host.url));
     this.queryParamsHandling = 'merge';
     this.queryParams = this.skyAppConfig.runtime.params.getAll();
-    this.target = this.window.nativeWindow.window.name || '_top';
+    if (this.window.nativeWindow.window.name && this.window.nativeWindow.window.name !== '') {
+      this.target = this.window.nativeWindow.window.name;
+    } else {
+      this.target = '_top';
+    }
   }
 }

--- a/runtime/directives/sky-app-link-external.directive.ts
+++ b/runtime/directives/sky-app-link-external.directive.ts
@@ -1,31 +1,36 @@
-import { Directive, Input, HostListener } from "@angular/core";
-import { SkyAppWindowRef } from "../window-ref";
-import { SkyAppConfig } from "../config";
+import { Directive, Input, HostListener, OnInit } from '@angular/core';
+import { SkyAppWindowRef } from '../window-ref';
+import { SkyAppConfig } from '@blackbaud/skyux-builder/runtime';
 import { HttpParams } from '@angular/common/http';
 
 @Directive({
-  selector: "[skyAppLinkExternal]"
+  selector: '[skyAppLinkExternal]'
 })
-export class SkyAppLinkExternalDirective {
-  @Input() skyAppLinkExternal: string;
+export class SkyAppLinkExternalDirective implements OnInit {
+  @Input() private skyAppLinkExternal: string;
+  private externalSPAUrl: string;
 
   constructor(
     private skyAppConfig: SkyAppConfig,
     private window: SkyAppWindowRef
   ) { }
 
-  @HostListener("click", ["$event"])
-  public onClick(event: MouseEvent) {
+  public ngOnInit() {
     const queryParams: any = this.skyAppConfig.runtime.params.getAll();
     const urlParts = this.skyAppLinkExternal.split('?');
 
-    let params = new HttpParams({ fromString: urlParts[1] })
+    let params = new HttpParams({ fromString: urlParts[1] });
     for (const key in queryParams) {
       if (queryParams.hasOwnProperty(key)) {
         params = params.append(key, queryParams[key]);
       }
     }
 
-    this.window.nativeWindow.location.href = `${this.skyAppConfig.skyux.host.url}${urlParts[0]}?${params.toString()}`;
+    this.externalSPAUrl = `${this.skyAppConfig.skyux.host.url}${urlParts[0]}?${params.toString()}`;
+  }
+
+  @HostListener('click', ['$event'])
+  public onClick(event: MouseEvent) {
+    this.window.nativeWindow.location.href = this.externalSPAUrl;
   }
 }


### PR DESCRIPTION
We need to navigate to an other SPA but maintain service and environment context. So, we need to sidestep the Angular router but still get the same behavior as `skyAppLink` to maintain the runtime context for the SPA.

- First commit for review on overall approach before writing tests