### PR TITLE
Using logger.logColor for Karma and Protractor

### DIFF
--- a/config/karma/shared.karma.conf.js
+++ b/config/karma/shared.karma.conf.js
@@ -1,6 +1,8 @@
 /*jslint node: true */
 'use strict';
 
+const logger = require('@blackbaud/skyux-logger');
+
 /**
  * Adds the necessary configuration for code coverage thresholds.
  * @param {*} config
@@ -93,7 +95,7 @@ function getConfig(config) {
     },
     reporters: ['mocha', 'coverage'],
     port: 9876,
-    colors: true,
+    colors: logger.logColor,
     logLevel: config.LOG_INFO,
     browserDisconnectTimeout: 3e5,
     browserDisconnectTolerance: 3,

--- a/config/protractor/protractor.conf.js
+++ b/config/protractor/protractor.conf.js
@@ -3,6 +3,7 @@
 
 const path = require('path');
 const SpecReporter = require('jasmine-spec-reporter').SpecReporter;
+const logger = require('@blackbaud/skyux-logger');
 
 exports.config = {
   allScriptsTimeout: 11000,
@@ -24,7 +25,7 @@ exports.config = {
   // seleniumAddress: 'http://localhost:4444/wd/hub',
   framework: 'jasmine',
   jasmineNodeOpts: {
-    showColors: true,
+    showColors: logger.logColor,
     defaultTimeoutInterval: 30000
   },
   useAllAngular2AppRoots: true,

--- a/test/config-karma-shared.spec.js
+++ b/test/config-karma-shared.spec.js
@@ -116,4 +116,13 @@ describe('config karma shared', () => {
     checkCodeCoverage('strict', 100);
   });
 
+  it('should pass the logColor flag to the config', () => {
+    mock('@blackbaud/skyux-logger', { logColor: false });
+    mock.reRequire('../config/karma/shared.karma.conf')({
+      set: (config) => {
+        expect(config.colors).toBe(false);
+      }
+    });
+  });
+
 });

--- a/test/config-protractor.spec.js
+++ b/test/config-protractor.spec.js
@@ -46,4 +46,10 @@ describe('config protractor test', () => {
     expect(jasmine.getEnv).toHaveBeenCalled();
     expect(called).toEqual(true);
   });
+
+  it('should pass the logColor flag to the config', () => {
+    mock('@blackbaud/skyux-logger', { logColor: false });
+    const lib = mock.reRequire('../config/protractor/protractor.conf.js');
+    expect(lib.config.jasmineNodeOpts.showColors).toBe(false);
+  });
 });


### PR DESCRIPTION
I foolishly missed updating the Karma and Protractor configurations to honor the newly created `@blackbaud/skyux-logger`.