### PR TITLE
Added 'keyboardEventInit' to test utility

### DIFF
--- a/runtime/testing/browser/test-utility-dom-event-options.ts
+++ b/runtime/testing/browser/test-utility-dom-event-options.ts
@@ -1,5 +1,5 @@
 export interface SkyAppTestUtilityDomEventOptions {
   bubbles?: boolean;
   cancelable?: boolean;
-  key?: string;
+  keyboardEventInit?: KeyboardEventInit;
 }

--- a/runtime/testing/browser/test-utility-dom-event-options.ts
+++ b/runtime/testing/browser/test-utility-dom-event-options.ts
@@ -1,4 +1,5 @@
 export interface SkyAppTestUtilityDomEventOptions {
   bubbles?: boolean;
   cancelable?: boolean;
+  key?: string;
 }

--- a/runtime/testing/browser/test-utility.ts
+++ b/runtime/testing/browser/test-utility.ts
@@ -6,12 +6,21 @@ export class SkyAppTestUtility {
     eventName: string,
     options?: SkyAppTestUtilityDomEventOptions
   ) {
-    const defaults = { bubbles: true, cancelable: true };
-    const { bubbles, cancelable } = Object.assign({}, defaults, options);
+    const defaults = {
+      bubbles: true,
+      cancelable: true,
+      keyboardEventInit: {}
+    };
 
-    const event = document.createEvent('CustomEvent');
-    event.initEvent(eventName, bubbles, cancelable);
+    const settings = Object.assign({}, defaults, options);
 
+    // Apply keyboard event options.
+    const event = Object.assign(
+      document.createEvent('CustomEvent'),
+      settings.keyboardEventInit
+    );
+
+    event.initEvent(eventName, settings.bubbles, settings.cancelable);
     element.dispatchEvent(event);
   }
 }


### PR DESCRIPTION
**Allows firing of keyboard events.**
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent

```
SkyAppTestUtility.fireDomEvent(autocompleteElement, 'keydown', {
  bubbles: true,
  keyboardEventInit: { key: 'Enter' }
});
```

FYI: I replaced all instances of `TestUtility` from SKY UX's spec files with success:
https://github.com/blackbaud/skyux2/pull/1598