### PR TITLE
Added module to runtime index

### DIFF
--- a/runtime/i18n/host-locale-provider.ts
+++ b/runtime/i18n/host-locale-provider.ts
@@ -7,7 +7,7 @@ import { Observable } from 'rxjs/Observable';
 
 import {
   SkyAppWindowRef
-} from '@blackbaud/skyux-builder/runtime';
+} from '@blackbaud/skyux-builder/runtime/window-ref';
 
 import { SkyAppLocaleInfo } from './locale-info';
 import { SkyAppLocaleProvider } from './locale-provider';

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -13,3 +13,4 @@ export * from './style-loader';
 export * from './viewport.service';
 export * from './omnibar-provider';
 export * from './omnibar-ready-args';
+export * from './runtime.module';


### PR DESCRIPTION
This will allow folks to import the runtime module via the barrel:

`import { SkyAppRuntimeModule } from '@blackbaud/skyux-builder/runtime'`