### PR TITLE
Using textContent instead of innerText for matcher

### DIFF
--- a/runtime/testing/browser/matchers.ts
+++ b/runtime/testing/browser/matchers.ts
@@ -33,7 +33,7 @@ let skyMatchers: jasmine.CustomMatcherFactories = {
           message: ''
         };
 
-        let actualText = el.innerText;
+        let actualText = el.textContent;
 
         if (trimWhitespace) {
           actualText = actualText.trim();


### PR DESCRIPTION
This adjustment was made for SKY UX, but since we're removing that in favor of Builder's matchers, it would be good to bring this over too:

https://github.com/blackbaud/skyux2/pull/1422