### PR TITLE
Added lcov to output types for istanbul

### DIFF
--- a/config/karma/shared.karma.conf.js
+++ b/config/karma/shared.karma.conf.js
@@ -78,7 +78,8 @@ function getConfig(config) {
       reporters: [
         { type: 'json' },
         { type: 'html' },
-        { type: 'text-summary' }
+        { type: 'text-summary' },
+        { type: 'lcov' }
       ],
       _onWriteReport: function (collector) {
         return remapIstanbul.remap(collector.getFinalCoverage());


### PR DESCRIPTION
Adding `lcov` to the outputs for Istanbul so we can make use of some code coverage tooling in VSCode.