### PR TITLE
Add better type info and documentation to SkyPactService.

### DIFF
--- a/runtime/pact.service.ts
+++ b/runtime/pact.service.ts
@@ -1,3 +1,5 @@
+import { PactWeb } from '@pact-foundation/pact-web';
+import { InteractionObject } from '@pact-foundation/pact-web/dsl/interaction';
 import { SkyAppConfig } from '@blackbaud/skyux-builder/runtime/config';
 
 declare var Pact: any;
@@ -7,7 +9,7 @@ declare var Pact: any;
  */
 export class SkyPactService {
 
-  private pactProviders: { [providerName: string]: any } = {};
+  private pactProviders: { [providerName: string]: PactWeb } = {};
 
   private matchersInternal: any;
 
@@ -27,28 +29,37 @@ export class SkyPactService {
     this.matchersInternal = Pact.Matchers;
   }
 
-  public addInteraction(provider: string, interaction: any) {
-
+  /**
+   * Add an interaction to the Mock Service.
+   * @param provider The name of the provider service.
+   * @param interaction The provider interaction.
+   */
+  public addInteraction(provider: string, interaction: InteractionObject): Promise<string> {
     return this.pactProviders[provider].addInteraction(interaction);
-
   }
 
-  public removeInteractions(provider: string) {
-
+  /**
+   * Clear up any interactions in the Mock Service.
+   * @param provider The name of the provider service.
+   */
+  public removeInteractions(provider: string): Promise<string> {
     return this.pactProviders[provider].removeInteractions();
-
   }
 
-  public finalize(provider: string) {
-
+  /**
+   * Writes the Pact file and clears any interactions left behind.
+   * @param provider The name of the provider service.
+   */
+  public finalize(provider: string): Promise<string> {
     return this.pactProviders[provider].finalize();
-
   }
 
-  public verify(provider: string) {
-
+  /**
+   * Checks with the Mock Service if the expected interactions have been exercised.
+   * @param provider The name of the provider service.
+   */
+  public verify(provider: string): Promise<string> {
     return this.pactProviders[provider].verify();
-
   }
 
   public get matchers() {


### PR DESCRIPTION
While working on pact tests for my SPA, it was confusing/misleading to work with the SkyPactService class since it did not accurately represent the parameters and return types of it's functions.  Since this is just a wrapper class around pact-js, I've added the missing type info and method descriptions based on the official pact-js site.  This should help developers writing pact tests in their SPAs.