### PR TITLE
Libraries > Separated transpile and bundle actions

### DIFF
--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -73,19 +73,25 @@ function writeTSConfig() {
         ]
       }
     },
-    'exclude': [
-      skyPagesConfigUtil.spaPathTemp('runtime')
+    files: [
+      skyPagesConfigUtil.spaPathTemp('index.ts')
     ]
   };
 
   fs.writeJSONSync(skyPagesConfigUtil.spaPathTemp('tsconfig.json'), config);
 }
 
+/**
+ * Create a "placeholder" module for Angular AoT compiler.
+ * This is needed to avoid breaking changes; in the future,
+ * we should require a module name be provided by the consumer.
+ */
 function writePlaceholderModule() {
-  const content = `import { NgModule } from '@angular/core';
-import './index';
+  const content = `
+import { NgModule } from '@angular/core';
 @NgModule({})
-export class SkyLibPlaceholderModule {}
+export abstract class SkyLibPlaceholderModule {}
+export * from './index';
 `;
 
   fs.writeFileSync(skyPagesConfigUtil.spaPathTemp('main.ts'), content, {

--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -73,7 +73,7 @@ function writeTSConfig() {
         ]
       }
     },
-    files: [
+    'files': [
       skyPagesConfigUtil.spaPathTemp('index.ts')
     ]
   };
@@ -87,11 +87,10 @@ function writeTSConfig() {
  * we should require a module name be provided by the consumer.
  */
 function writePlaceholderModule() {
-  const content = `
-import { NgModule } from '@angular/core';
-@NgModule({})
-export abstract class SkyLibPlaceholderModule {}
+  const content = `import { NgModule } from '@angular/core';
 export * from './index';
+@NgModule({})
+export class SkyLibPlaceholderModule {}
 `;
 
   fs.writeFileSync(skyPagesConfigUtil.spaPathTemp('main.ts'), content, {

--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -1,13 +1,13 @@
 /*jshint node: true*/
 'use strict';
 
+const spawn = require('cross-spawn');
 const fs = require('fs-extra');
 const rimraf = require('rimraf');
 const logger = require('@blackbaud/skyux-logger');
 
 const stageTypeScriptFiles = require('./utils/stage-library-ts');
 const preparePackage = require('./utils/prepare-library-package');
-const webpackConfig = require('../config/webpack/build-public-library.webpack.config.js');
 const skyPagesConfigUtil = require('../config/sky-pages/sky-pages.config');
 const runCompiler = require('./utils/run-compiler');
 const tsLinter = require('./utils/ts-linter');
@@ -73,8 +73,8 @@ function writeTSConfig() {
         ]
       }
     },
-    'files': [
-      skyPagesConfigUtil.spaPathTemp('index.ts')
+    'exclude': [
+      skyPagesConfigUtil.spaPathTemp('runtime')
     ]
   };
 
@@ -93,9 +93,40 @@ export class SkyLibPlaceholderModule {}
   });
 }
 
-function transpile(skyPagesConfig, webpack) {
+/**
+ * Creates a UMD JavaScript bundle.
+ * @param {*} skyPagesConfig
+ * @param {*} webpack
+ */
+function createBundle(skyPagesConfig, webpack) {
+  const webpackConfig = require('../config/webpack/build-public-library.webpack.config');
   const config = webpackConfig.getWebpackConfig(skyPagesConfig);
   return runCompiler(webpack, config);
+}
+
+/**
+ * Transpiles TypeScript files into JavaScript files
+ * to be included with the NPM package.
+ */
+function transpile() {
+  return new Promise((resolve, reject) => {
+    const result = spawn.sync(
+      'node',
+      [
+        skyPagesConfigUtil.spaPath('node_modules', '.bin', 'ngc'),
+        '--project',
+        skyPagesConfigUtil.spaPathTemp('tsconfig.json')
+      ],
+      { stdio: 'inherit' }
+    );
+
+    if (result.err) {
+      reject(result.err);
+      return;
+    }
+
+    resolve();
+  });
 }
 
 module.exports = (skyPagesConfig, webpack) => {
@@ -106,7 +137,8 @@ module.exports = (skyPagesConfig, webpack) => {
   writePlaceholderModule();
   copyRuntime();
 
-  return transpile(skyPagesConfig, webpack)
+  return createBundle(skyPagesConfig, webpack)
+    .then(() => transpile())
     .then(() => {
       cleanRuntime();
       preparePackage();

--- a/config/webpack/build-public-library.webpack.config.js
+++ b/config/webpack/build-public-library.webpack.config.js
@@ -48,7 +48,7 @@ function getWebpackConfig(skyPagesConfig) {
     .map(key => parseRegExp(key));
 
   return {
-    entry: skyPagesConfigUtil.spaPathTemp('main.ts'),
+    entry: skyPagesConfigUtil.spaPathTemp('index.ts'),
     output: {
       path: skyPagesConfigUtil.spaPath('dist', 'bundles'),
       filename: 'bundle.umd.js',

--- a/config/webpack/build-public-library.webpack.config.js
+++ b/config/webpack/build-public-library.webpack.config.js
@@ -82,7 +82,9 @@ function getWebpackConfig(skyPagesConfig) {
       ]
     },
     plugins: [
-      // Generates an aot JavaScript bundle.
+      // Generates an AoT JavaScript bundle.
+      // TODO: Remove this in favor of Angular's native library bundler,
+      // once we've upgraded to Angular version 6.
       new ngtools.AotPlugin({
         tsConfigPath: skyPagesConfigUtil.spaPathTemp('tsconfig.json'),
         entryModule: skyPagesConfigUtil.spaPathTemp('main.ts') + '#SkyLibPlaceholderModule',

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "karma-webpack": "2.0.3",
     "loader-utils": "1.1.0",
     "lodash.mergewith": "4.6.0",
-    "ngc-webpack": "3.0.0",
     "node-sass": "4.5.3",
     "node-sass-tilde-importer": "1.0.2",
     "open": "0.0.5",

--- a/test/cli-build-public-library.spec.js
+++ b/test/cli-build-public-library.spec.js
@@ -115,10 +115,11 @@ describe('cli build-public-library', () => {
     cliCommand({}, mockWebpack).then(() => {
       const args = spy.calls.argsFor(0);
       expect(args[0]).toEqual('main.ts');
-      expect(args[1]).toEqual(`import { NgModule } from '@angular/core';
-import './index';
+      expect(args[1]).toEqual(`
+import { NgModule } from '@angular/core';
 @NgModule({})
-export class SkyLibPlaceholderModule {}
+export abstract class SkyLibPlaceholderModule {}
+export * from './index';
 `);
       done();
     });

--- a/test/cli-build-public-library.spec.js
+++ b/test/cli-build-public-library.spec.js
@@ -115,11 +115,10 @@ describe('cli build-public-library', () => {
     cliCommand({}, mockWebpack).then(() => {
       const args = spy.calls.argsFor(0);
       expect(args[0]).toEqual('main.ts');
-      expect(args[1]).toEqual(`
-import { NgModule } from '@angular/core';
-@NgModule({})
-export abstract class SkyLibPlaceholderModule {}
+      expect(args[1]).toEqual(`import { NgModule } from '@angular/core';
 export * from './index';
+@NgModule({})
+export class SkyLibPlaceholderModule {}
 `);
       done();
     });

--- a/test/config-webpack-build-public-library.spec.js
+++ b/test/config-webpack-build-public-library.spec.js
@@ -82,6 +82,9 @@ describe('config webpack build public library', () => {
             '@angular/common': '4.3.6',
             '@pact-foundation/pact-web': '5.3.0',
             'zone.js': '0.8.10'
+          },
+          peerDependencies: {
+            '@angular/core': '4.3.6'
           }
         };
       }
@@ -90,6 +93,9 @@ describe('config webpack build public library', () => {
         dependencies: {
           '@blackbaud/skyux': '2.13.0',
           '@blackbaud-internal/skyux-lib-testing': 'latest'
+        },
+        peerDependencies: {
+          '@angular/core': '4.3.6'
         }
       };
     });
@@ -99,6 +105,7 @@ describe('config webpack build public library', () => {
       /^@angular\/common/,
       /^@pact\-foundation\/pact\-web/,
       /^zone\.js/,
+      /^@angular\/core/,
       /^@blackbaud\/skyux/,
       /^@blackbaud\-internal\/skyux\-lib\-testing/
     ]);


### PR DESCRIPTION
Resolves: https://github.com/blackbaud/skyux2/issues/1851

@Blackbaud-BobbyEarl I know we talked about avoiding `child_spawn`, but in this case I couldn't find a way around it. Library builds are failing because we're attempting to transpile and bundle in the same step, which causes some problems during AoT. To fix it, I'm transpiling _after_ the bundle has been created so that they don't interfere with one another.

To transpile the files, I need to use Angular's `ngc` (for the metadata), but they don't provide an NPM utility that can be used programmatically, from what I gathered. Also, nearly every tutorial I found recommended that we run `ngc` through the command-line. Another critical thing to note: Angular 6 provides a first-class way to generate libraries, so the changes in this pull request should be temporary until we can upgrade Builder/UX to the latest Angular/TypeScript.

Example tutorial: https://medium.com/@cyrilletuzi/how-to-build-and-publish-an-angular-module-7ad19c0b4464