### PR TITLE
Fixed library build failures on Windows machines

### DIFF
--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -132,7 +132,7 @@ function transpile() {
 
     // Catch non-zero status codes.
     if (result.status !== 0) {
-      reject(new Error(`Child process exited with status code ${result.status}.`));
+      reject(new Error(`Angular compiler (ngc) exited with status code ${result.status}.`));
       return;
     }
 

--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -124,8 +124,15 @@ function transpile() {
       { stdio: 'inherit' }
     );
 
+    // Catch ngc errors.
     if (result.err) {
       reject(result.err);
+      return;
+    }
+
+    // Catch non-zero status codes.
+    if (result.status !== 0) {
+      reject(new Error(`Child process exited with status code ${result.status}.`));
       return;
     }
 

--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -116,9 +116,8 @@ function createBundle(skyPagesConfig, webpack) {
 function transpile() {
   return new Promise((resolve, reject) => {
     const result = spawn.sync(
-      'node',
+      skyPagesConfigUtil.spaPath('node_modules', '.bin', 'ngc'),
       [
-        skyPagesConfigUtil.spaPath('node_modules', '.bin', 'ngc'),
         '--project',
         skyPagesConfigUtil.spaPathTemp('tsconfig.json')
       ],

--- a/test/cli-build-public-library.spec.js
+++ b/test/cli-build-public-library.spec.js
@@ -186,7 +186,9 @@ export class SkyLibPlaceholderModule {}
       status: 1
     });
     cliCommand({}, mockWebpack).then(() => {
-      expect(spy).toHaveBeenCalledWith(new Error(`Child process exited with status code 1.`));
+      expect(spy).toHaveBeenCalledWith(
+        new Error(`Angular compiler (ngc) exited with status code 1.`)
+      );
       done();
     });
   });

--- a/test/cli-build-public-library.spec.js
+++ b/test/cli-build-public-library.spec.js
@@ -22,7 +22,9 @@ describe('cli build-public-library', () => {
 
     mockSpawn = {
       sync() {
-        return {};
+        return {
+          status: 0
+        };
       }
     };
 
@@ -172,6 +174,19 @@ export class SkyLibPlaceholderModule {}
     });
     cliCommand({}, mockWebpack).then(() => {
       expect(spy).toHaveBeenCalledWith('something bad happened');
+      done();
+    });
+  });
+
+  it('should catch non-zero status codes during transpilation', (done) => {
+    const cliCommand = mock.reRequire(requirePath);
+    const spy = spyOn(logger, 'error').and.returnValue();
+    spyOn(mockSpawn, 'sync').and.returnValue({
+      err: null,
+      status: 1
+    });
+    cliCommand({}, mockWebpack).then(() => {
+      expect(spy).toHaveBeenCalledWith(new Error(`Child process exited with status code 1.`));
       done();
     });
   });


### PR DESCRIPTION
`skyux build-public-library` is not working on Windows machines due to an incorrect usage of `cross-spawn`.

Also, I'm passing up the status code to fail the build if an error is encountered.