### PR TITLE
Reverted Pact interaction type for backwards compatibility

### DIFF
--- a/runtime/pact.service.ts
+++ b/runtime/pact.service.ts
@@ -1,5 +1,4 @@
 import { PactWeb } from '@pact-foundation/pact-web';
-import { InteractionObject } from '@pact-foundation/pact-web/dsl/interaction';
 import { SkyAppConfig } from '@blackbaud/skyux-builder/runtime/config';
 
 declare var Pact: any;
@@ -34,7 +33,7 @@ export class SkyPactService {
    * @param provider The name of the provider service.
    * @param interaction The provider interaction.
    */
-  public addInteraction(provider: string, interaction: InteractionObject): Promise<string> {
+  public addInteraction(provider: string, interaction: any): Promise<string> {
     return this.pactProviders[provider].addInteraction(interaction);
   }
 


### PR DESCRIPTION
Resolves: https://github.com/blackbaud/skyux2/issues/1852

The type will be added back in the new `@skyux-sdk/pact` library:
https://github.com/blackbaud/skyux-sdk-pact/blob/master/src/app/public/pact.service.ts#L45
