### PR TITLE
[HOLD] RC > Resolve locale resources

### DIFF
--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -72,6 +72,9 @@ function writeTSConfig() {
       'paths': {
         '@blackbaud/skyux-builder/*': [
           '*'
+        ],
+        '.skypageslocales/*': [
+          '../src/assets/locales/*'
         ]
       }
     },

--- a/lib/locale-assets-processor.js
+++ b/lib/locale-assets-processor.js
@@ -11,19 +11,26 @@ const localesPath = ['src', 'assets', 'locales'];
 const defaultLocaleFileName = 'resources_en_US.json';
 const defaultFile = tempPath(defaultLocaleFileName);
 
-const libPath = spaPath(
-  'node_modules',
-  '@blackbaud',
-  '**',
-  ...localesPath
-);
-
-const libInternalPath = spaPath(
-  'node_modules',
-  '@blackbaud-internal',
-  '**',
-  ...localesPath
-);
+const libPaths = [
+  spaPath(
+    'node_modules',
+    '@blackbaud',
+    '**',
+    ...localesPath
+  ),
+  spaPath(
+    'node_modules',
+    '@blackbaud-internal',
+    '**',
+    ...localesPath
+  ),
+  spaPath(
+    'node_modules',
+    '@skyux',
+    '**',
+    ...localesPath
+  )
+];
 
 function tempPath(...args) {
   return spaPath('.skypageslocales', ...args);
@@ -88,9 +95,12 @@ function getNonDefaultLocaleFiles(dirname) {
 }
 
 function mergeDefaultLocaleFiles() {
-  const libFiles = getDefaultLocaleFiles(libPath);
-  const libInternalFiles = getDefaultLocaleFiles(libInternalPath);
-  const contents = extendJson(...libFiles, ...libInternalFiles, defaultFile);
+  const libFiles = libPaths.reduce((accumulator, libPath) => {
+    return accumulator.concat(
+      getDefaultLocaleFiles(libPath)
+    );
+  }, []);
+  const contents = extendJson(...libFiles, defaultFile);
   fs.writeJsonSync(defaultFile, contents);
 }
 
@@ -103,8 +113,11 @@ function mergeNonDefaultLocaleFiles() {
     });
 
   // Extend all SPA files with library files.
-  getNonDefaultLocaleFiles(libPath)
-    .concat(getNonDefaultLocaleFiles(libInternalPath))
+  libPaths.reduce((accumulator, libPath) => {
+    return accumulator.concat(
+      getNonDefaultLocaleFiles(libPath)
+    );
+  }, [])
     .forEach(libFile => {
       const basename = path.basename(libFile);
       const spaFile = tempPath(basename);

--- a/test/lib-locale-assets-processor.spec.js
+++ b/test/lib-locale-assets-processor.spec.js
@@ -150,6 +150,9 @@ describe('Locale assets processor', () => {
       },
       '/node_modules/@blackbaud-internal/skyux-lib-bar/assets/locales/resources_en_CA.json': {
         lib_internal_en_ca_key: { _description: '', message: '[en_CA] lib internal en_CA message' }
+      },
+      '/node_modules/@skyux/core/assets/locales/resources_en_US.json': {
+        lib_core_key: { _description: '', message: '[en_US] lib core message' }
       }
     };
 
@@ -158,7 +161,6 @@ describe('Locale assets processor', () => {
     files['.skypageslocales/resources_fr_CA.json'] = files['src/assets/locales/resources_*.json'];
 
     spyOn(mockGlob, 'sync').and.callFake(expression => {
-      console.log('expression:', expression);
       let globFiles;
       switch (expression) {
         // Default library files
@@ -183,6 +185,12 @@ describe('Locale assets processor', () => {
         ];
         break;
 
+        case 'node_modules/@skyux/**/src/assets/locales/@(resources_en_US.json|resources_en-US.json)':
+        globFiles = [
+          '/node_modules/@skyux/core/assets/locales/resources_en_US.json'
+        ];
+        break;
+
         // All internal library files
         case 'node_modules/@blackbaud-internal/**/src/assets/locales/resources_*.json':
         globFiles = [
@@ -200,6 +208,7 @@ describe('Locale assets processor', () => {
         ];
         break;
 
+        default:
         case '.skypageslocales/resources_*.json':
         globFiles = [];
         break;
@@ -221,6 +230,7 @@ describe('Locale assets processor', () => {
     processor.prepareLocaleFiles();
 
     expect(files['.skypageslocales/resources_en_US.json']).toEqual({
+      lib_core_key: { _description: '', message: '[en_US] lib core message' },
       spa_key1: { _description: '', message: '[en_US] spa message 1' },
       spa_key2: { _description: '', message: '[en_US] spa message 2' },
       lib_key1: { _description: '', message: '[en_US] lib message 1' },
@@ -231,6 +241,7 @@ describe('Locale assets processor', () => {
     });
 
     expect(files['.skypageslocales/resources_fr_CA.json']).toEqual({
+      lib_core_key: { _description: '', message: '[en_US] lib core message' },
       spa_key1: { _description: '', message: '[fr_CA] spa message 1' },
       spa_key2: { _description: '', message: '[en_US] spa message 2' },
       spa_fr_key1: { _description: '', message: '[fr_CA] spa fr message' },
@@ -244,6 +255,7 @@ describe('Locale assets processor', () => {
     });
 
     expect(files['.skypageslocales/resources_en_CA.json']).toEqual({
+      lib_core_key: { _description: '', message: '[en_US] lib core message' },
       spa_key1: { _description: '', message: '[en_US] spa message 1' },
       spa_key2: { _description: '', message: '[en_US] spa message 2' },
       lib_key1: { _description: '', message: '[en_US] lib message 1' },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,9 @@
       "@blackbaud/skyux-builder/*": [
         "./node_modules/@blackbaud/skyux-builder/*",
         "./*"
+      ],
+      ".skypageslocales/*": [
+        ".skypageslocales/*"
       ]
     }
   },


### PR DESCRIPTION
This branch will allow SKY UX libraries to reference `.skypageslocales` resource files statically.

SKY UX 2 libraries will need this (in particular) to avoid breaking changes with how they're currently handling resources. `SkyResources` is used internally by SKY UX components, but it is synchronous (see: https://github.com/blackbaud/skyux2/blob/master/src/modules/resources/resources.ts#L2).

However, the new libraries need to use Builder's `SkyAppResources` service, which is asynchronous.

This pull request will allow libraries to reference the static files generated by Builder in a _synchronous_ way, until the libraries can release a breaking change to accommodate the asynchronous behavior of the service.

```
// Synchronous retrieval:
private resources = require('.skypageslocales/resources_en_US.json');

public getString(key: string): string {
  return this.resources[key].message;
}
```

Example, being used by `@skyux/core`: https://github.com/blackbaud/skyux-core/blob/abc5b71b8339c1e9269f493ef4f3887751c93288/src/app/public/modules/numeric/numeric.service.ts#L24