### PR TITLE
Resolve locale resources

### DIFF
--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -70,6 +70,9 @@ function writeTSConfig() {
       'paths': {
         '@blackbaud/skyux-builder/*': [
           '*'
+        ],
+        '.skypageslocales/*': [
+          '../src/assets/locales/*'
         ]
       }
     },

--- a/cli/test.js
+++ b/cli/test.js
@@ -25,11 +25,6 @@ function test(command, argv) {
 
   let lintResult;
 
-  function exit(exitCode) {
-    logger.info(`Karma has exited with ${exitCode}.`);
-    process.exit(exitCode);
-  }
-
   const onRunStart = () => {
     localeAssetsProcessor.prepareLocaleFiles();
     lintResult = tsLinter.lintSync();
@@ -53,11 +48,13 @@ function test(command, argv) {
       }
     }
 
-    exit(exitCode);
+    logger.info(`Karma has exited with ${exitCode}.`);
+    process.exit(exitCode);
   };
 
   const onBrowserError = () => {
-    exit(1);
+    const stopper = require('karma').stopper;
+    stopper.stop({}, () => onExit(1));
   };
 
   if (specsGlob.length === 0) {

--- a/cli/test.js
+++ b/cli/test.js
@@ -12,6 +12,7 @@ function test(command, argv) {
   const glob = require('glob');
   const tsLinter = require('./utils/ts-linter');
   const configResolver = require('./utils/config-resolver');
+  const localeAssetsProcessor = require('../lib/locale-assets-processor');
 
   argv = argv || process.argv;
   argv.command = command;
@@ -25,6 +26,7 @@ function test(command, argv) {
   let lintResult;
 
   const onRunStart = () => {
+    localeAssetsProcessor.prepareLocaleFiles();
     lintResult = tsLinter.lintSync();
   };
 

--- a/cli/test.js
+++ b/cli/test.js
@@ -25,6 +25,11 @@ function test(command, argv) {
 
   let lintResult;
 
+  function exit(exitCode) {
+    logger.info(`Karma has exited with ${exitCode}.`);
+    process.exit(exitCode);
+  }
+
   const onRunStart = () => {
     localeAssetsProcessor.prepareLocaleFiles();
     lintResult = tsLinter.lintSync();
@@ -48,8 +53,11 @@ function test(command, argv) {
       }
     }
 
-    logger.info(`Karma has exited with ${exitCode}.`);
-    process.exit(exitCode);
+    exit(exitCode);
+  };
+
+  const onBrowserError = () => {
+    exit(1);
   };
 
   if (specsGlob.length === 0) {
@@ -60,6 +68,7 @@ function test(command, argv) {
   const server = new Server(karmaConfig, onExit);
   server.on('run_start', onRunStart);
   server.on('run_complete', onRunComplete);
+  server.on('browser_error', onBrowserError);
   server.start();
 }
 

--- a/config/webpack/test.webpack.config.js
+++ b/config/webpack/test.webpack.config.js
@@ -101,6 +101,10 @@ function getWebpackConfig(skyPagesConfig, argv) {
         {
           test: /\.html$/,
           loader: 'raw-loader'
+        },
+        {
+          test: /\.json$/,
+          loader: 'json-loader'
         }
       ]
     },

--- a/config/webpack/test.webpack.config.js
+++ b/config/webpack/test.webpack.config.js
@@ -101,10 +101,6 @@ function getWebpackConfig(skyPagesConfig, argv) {
         {
           test: /\.html$/,
           loader: 'raw-loader'
-        },
-        {
-          test: /\.json$/,
-          loader: 'json-loader'
         }
       ]
     },

--- a/lib/locale-assets-processor.js
+++ b/lib/locale-assets-processor.js
@@ -11,19 +11,26 @@ const localesPath = ['src', 'assets', 'locales'];
 const defaultLocaleFileName = 'resources_en_US.json';
 const defaultFile = tempPath(defaultLocaleFileName);
 
-const libPath = spaPath(
-  'node_modules',
-  '@blackbaud',
-  '**',
-  ...localesPath
-);
-
-const libInternalPath = spaPath(
-  'node_modules',
-  '@blackbaud-internal',
-  '**',
-  ...localesPath
-);
+const libPaths = [
+  spaPath(
+    'node_modules',
+    '@blackbaud',
+    '**',
+    ...localesPath
+  ),
+  spaPath(
+    'node_modules',
+    '@blackbaud-internal',
+    '**',
+    ...localesPath
+  ),
+  spaPath(
+    'node_modules',
+    '@skyux',
+    '**',
+    ...localesPath
+  )
+];
 
 function tempPath(...args) {
   return spaPath('.skypageslocales', ...args);
@@ -88,9 +95,12 @@ function getNonDefaultLocaleFiles(dirname) {
 }
 
 function mergeDefaultLocaleFiles() {
-  const libFiles = getDefaultLocaleFiles(libPath);
-  const libInternalFiles = getDefaultLocaleFiles(libInternalPath);
-  const contents = extendJson(...libFiles, ...libInternalFiles, defaultFile);
+  const libFiles = libPaths.reduce((accumulator, libPath) => {
+    return accumulator.concat(
+      getDefaultLocaleFiles(libPath)
+    );
+  }, []);
+  const contents = extendJson(...libFiles, defaultFile);
   fs.writeJsonSync(defaultFile, contents);
 }
 
@@ -103,8 +113,11 @@ function mergeNonDefaultLocaleFiles() {
     });
 
   // Extend all SPA files with library files.
-  getNonDefaultLocaleFiles(libPath)
-    .concat(getNonDefaultLocaleFiles(libInternalPath))
+  libPaths.reduce((accumulator, libPath) => {
+    return accumulator.concat(
+      getNonDefaultLocaleFiles(libPath)
+    );
+  }, [])
     .forEach(libFile => {
       const basename = path.basename(libFile);
       const spaFile = tempPath(basename);

--- a/lib/locale-assets-processor.js
+++ b/lib/locale-assets-processor.js
@@ -95,11 +95,10 @@ function getNonDefaultLocaleFiles(dirname) {
 }
 
 function mergeDefaultLocaleFiles() {
-  const libFiles = libPaths.reduce((accumulator, libPath) => {
-    return accumulator.concat(
+  const libFiles = libPaths.reduce((accumulator, libPath) =>
+    accumulator.concat(
       getDefaultLocaleFiles(libPath)
-    );
-  }, []);
+    ), []);
   const contents = extendJson(...libFiles, defaultFile);
   fs.writeJsonSync(defaultFile, contents);
 }
@@ -113,11 +112,10 @@ function mergeNonDefaultLocaleFiles() {
     });
 
   // Extend all SPA files with library files.
-  libPaths.reduce((accumulator, libPath) => {
-    return accumulator.concat(
+  libPaths.reduce((accumulator, libPath) =>
+    accumulator.concat(
       getNonDefaultLocaleFiles(libPath)
-    );
-  }, [])
+    ), [])
     .forEach(libFile => {
       const basename = path.basename(libFile);
       const spaFile = tempPath(basename);

--- a/test/cli-test.spec.js
+++ b/test/cli-test.spec.js
@@ -165,7 +165,8 @@ describe('cli test', () => {
           callback();
         };
         this.start = () => {};
-      }
+      },
+      stopper: { stop: () => {} }
     });
     const test = mock.reRequire('../cli/test');
     test('test');
@@ -197,7 +198,8 @@ describe('cli test', () => {
           callback();
         };
         this.start = () => {};
-      }
+      },
+      stopper: { stop: () => {} }
     });
     const test = mock.reRequire('../cli/test');
     test('test');
@@ -224,7 +226,8 @@ describe('cli test', () => {
         _onExit = onExit;
         this.on = (hook, callback) => callback();
         this.start = () => {};
-      }
+      },
+      stopper: { stop: () => {} }
     });
 
     const test = mock.reRequire('../cli/test');
@@ -260,7 +263,8 @@ describe('cli test', () => {
           callback();
         };
         this.start = () => {};
-      }
+      },
+      stopper: { stop: () => {} }
     });
     mock.reRequire('../cli/test')('test');
     _onExit(0);
@@ -273,20 +277,24 @@ describe('cli test', () => {
         parseConfig: () => {}
       },
       Server: function (config, callback) {
-        callback(0);
         this.on = (hook, cb) => {
           if (hook === 'browser_error') {
             cb();
           }
         };
         this.start = () => {};
+      },
+      stopper: {
+        stop: (config, callback) => {
+          callback();
+        }
       }
     });
     const test = mock.reRequire('../cli/test');
     test('test');
     expect(logger.info).toHaveBeenCalledWith(
-      'Karma has exited with 0.'
+      'Karma has exited with 1.'
     );
-    expect(process.exit).toHaveBeenCalledWith(0);
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 });

--- a/test/cli-test.spec.js
+++ b/test/cli-test.spec.js
@@ -266,4 +266,27 @@ describe('cli test', () => {
     _onExit(0);
     expect(spy).toHaveBeenCalled();
   });
+
+  it('should handle browser errors', () => {
+    mock('karma', {
+      config: {
+        parseConfig: () => {}
+      },
+      Server: function (config, callback) {
+        callback(0);
+        this.on = (hook, cb) => {
+          if (hook === 'browser_error') {
+            cb();
+          }
+        };
+        this.start = () => {};
+      }
+    });
+    const test = mock.reRequire('../cli/test');
+    test('test');
+    expect(logger.info).toHaveBeenCalledWith(
+      'Karma has exited with 0.'
+    );
+    expect(process.exit).toHaveBeenCalledWith(0);
+  });
 });

--- a/test/cli-test.spec.js
+++ b/test/cli-test.spec.js
@@ -6,6 +6,7 @@ const logger = require('@blackbaud/skyux-logger');
 
 describe('cli test', () => {
   let originalArgv = process.argv;
+  let mockLocaleAssetsProcessor;
 
   function MockServer() { }
 
@@ -13,6 +14,10 @@ describe('cli test', () => {
   MockServer.prototype.start = function () {};
 
   beforeEach(() => {
+    mockLocaleAssetsProcessor = {
+      prepareLocaleFiles: () => {}
+    };
+
     spyOn(global, 'setTimeout').and.callFake(cb => cb());
     spyOn(process, 'exit').and.returnValue();
     spyOn(logger, 'info').and.returnValue();
@@ -34,6 +39,8 @@ describe('cli test', () => {
     mock('../cli/utils/config-resolver', {
       resolve: (command) => `${command}-config.js`
     });
+
+    mock('../lib/locale-assets-processor', mockLocaleAssetsProcessor);
   });
 
   afterEach(() => {
@@ -238,5 +245,25 @@ describe('cli test', () => {
       'No spec files located. Skipping test command.'
     );
     expect(process.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('should generate locale files before each karma run', () => {
+    const spy = spyOn(mockLocaleAssetsProcessor, 'prepareLocaleFiles').and.callThrough();
+    let _onExit;
+    mock('karma', {
+      config: {
+        parseConfig: () => {}
+      },
+      Server: function (config, onExit) {
+        _onExit = onExit;
+        this.on = (hook, callback) => {
+          callback();
+        };
+        this.start = () => {};
+      }
+    });
+    mock.reRequire('../cli/test')('test');
+    _onExit(0);
+    expect(spy).toHaveBeenCalled();
   });
 });

--- a/test/lib-locale-assets-processor.spec.js
+++ b/test/lib-locale-assets-processor.spec.js
@@ -150,6 +150,9 @@ describe('Locale assets processor', () => {
       },
       '/node_modules/@blackbaud-internal/skyux-lib-bar/assets/locales/resources_en_CA.json': {
         lib_internal_en_ca_key: { _description: '', message: '[en_CA] lib internal en_CA message' }
+      },
+      '/node_modules/@skyux/core/assets/locales/resources_en_US.json': {
+        lib_core_key: { _description: '', message: '[en_US] lib core message' }
       }
     };
 
@@ -158,7 +161,6 @@ describe('Locale assets processor', () => {
     files['.skypageslocales/resources_fr_CA.json'] = files['src/assets/locales/resources_*.json'];
 
     spyOn(mockGlob, 'sync').and.callFake(expression => {
-      console.log('expression:', expression);
       let globFiles;
       switch (expression) {
         // Default library files
@@ -183,6 +185,12 @@ describe('Locale assets processor', () => {
         ];
         break;
 
+        case 'node_modules/@skyux/**/src/assets/locales/@(resources_en_US.json|resources_en-US.json)':
+        globFiles = [
+          '/node_modules/@skyux/core/assets/locales/resources_en_US.json'
+        ];
+        break;
+
         // All internal library files
         case 'node_modules/@blackbaud-internal/**/src/assets/locales/resources_*.json':
         globFiles = [
@@ -200,6 +208,7 @@ describe('Locale assets processor', () => {
         ];
         break;
 
+        default:
         case '.skypageslocales/resources_*.json':
         globFiles = [];
         break;
@@ -221,6 +230,7 @@ describe('Locale assets processor', () => {
     processor.prepareLocaleFiles();
 
     expect(files['.skypageslocales/resources_en_US.json']).toEqual({
+      lib_core_key: { _description: '', message: '[en_US] lib core message' },
       spa_key1: { _description: '', message: '[en_US] spa message 1' },
       spa_key2: { _description: '', message: '[en_US] spa message 2' },
       lib_key1: { _description: '', message: '[en_US] lib message 1' },
@@ -231,6 +241,7 @@ describe('Locale assets processor', () => {
     });
 
     expect(files['.skypageslocales/resources_fr_CA.json']).toEqual({
+      lib_core_key: { _description: '', message: '[en_US] lib core message' },
       spa_key1: { _description: '', message: '[fr_CA] spa message 1' },
       spa_key2: { _description: '', message: '[en_US] spa message 2' },
       spa_fr_key1: { _description: '', message: '[fr_CA] spa fr message' },
@@ -244,6 +255,7 @@ describe('Locale assets processor', () => {
     });
 
     expect(files['.skypageslocales/resources_en_CA.json']).toEqual({
+      lib_core_key: { _description: '', message: '[en_US] lib core message' },
       spa_key1: { _description: '', message: '[en_US] spa message 1' },
       spa_key2: { _description: '', message: '[en_US] spa message 2' },
       lib_key1: { _description: '', message: '[en_US] lib message 1' },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,9 @@
       "@blackbaud/skyux-builder/*": [
         "./node_modules/@blackbaud/skyux-builder/*",
         "./*"
+      ],
+      ".skypageslocales/*": [
+        ".skypageslocales/*"
       ]
     }
   },


### PR DESCRIPTION
**This branch accomplishes the following:**
1. Allow SKY UX libraries to reference `.skypageslocales` resource files statically (see description below)
1. Related to above, we also need to generate resource files during `skyux test`.
1. Finally, I noticed that Karma is not catching browser errors. I added the appropriate hook for that.

**Why allow SKY UX libraries to reference resource files statically?**

SKY UX 2 libraries will need this (in particular) to avoid breaking changes with how they're currently handling resources. `SkyResources` is used internally by SKY UX components, but it is synchronous (see: https://github.com/blackbaud/skyux2/blob/master/src/modules/resources/resources.ts#L2).

However, the new libraries need to use Builder's `SkyAppResources` service, which is asynchronous.

This pull request will allow libraries to reference the static files generated by Builder in a _synchronous_ way, until the libraries can release a breaking change to accommodate the asynchronous behavior of the service.

```
// Synchronous retrieval:
private resources = require('!json-loader!.skypageslocales/resources_en_US.json');

public getString(key: string): string {
  return this.resources[key].message;
}
```

Example, being used by `@skyux/core`:
https://github.com/blackbaud/skyux-core/pull/4/files#diff-2cae0aabc5da219240008c726619282eR24