### PR TITLE
Re-added stats to the build promise result

### DIFF
--- a/cli/build.js
+++ b/cli/build.js
@@ -14,8 +14,9 @@ const runBuild = require('./utils/run-build');
  */
 function build(argv, skyPagesConfig, webpack) {
   return runBuild(argv, skyPagesConfig, webpack)
-    .then(() => {
+    .then((stats) => {
       logger.info('Build successfully completed.');
+      return stats;
     })
     .catch(err => {
       logger.error(err);

--- a/test/cli-build.spec.js
+++ b/test/cli-build.spec.js
@@ -16,6 +16,15 @@ describe('cli build', () => {
     });
   });
 
+  it('should return build stats when the build is completed successful', (done) => {
+    mock('../cli/utils/run-build', () => Promise.resolve({ foo: 'bar' }));
+
+    mock.reRequire('../cli/build')('build', {}, {}).then((stats) => {
+      expect(stats.foo).toEqual('bar');
+      done();
+    });
+  });
+
   it('should log errors and set exit code to 1', (done) => {
     const errors = 'errors';
 

--- a/test/cli-build.spec.js
+++ b/test/cli-build.spec.js
@@ -6,7 +6,7 @@ const logger = require('@blackbaud/skyux-logger');
 
 describe('cli build', () => {
 
-  it('should log when the build is completed successful', (done) => {
+  it('should log when the build is completed successfully', (done) => {
     spyOn(logger, 'info');
     mock('../cli/utils/run-build', () => Promise.resolve());
 
@@ -16,7 +16,7 @@ describe('cli build', () => {
     });
   });
 
-  it('should return build stats when the build is completed successful', (done) => {
+  it('should return build stats when the build is completed successfully', (done) => {
     mock('../cli/utils/run-build', () => Promise.resolve({ foo: 'bar' }));
 
     mock.reRequire('../cli/build')('build', {}, {}).then((stats) => {


### PR DESCRIPTION
SKY UX references Builder's `/cli/build.js` file during its visual tests. An older version of Builder used to return `stats` in the build's promise, but now it doesn't. This fails our visual tests.

Where SKY UX is referencing the build result:
https://github.com/blackbaud/skyux2/blob/master/skyux-spa-visual-tests/config/utils/start-visual.js#L192