### PR TITLE
Fix lint/tsc issues when the strict tsc flag is true

### DIFF
--- a/runtime/bootstrapper.ts
+++ b/runtime/bootstrapper.ts
@@ -28,7 +28,7 @@ export class SkyAppBootstrapper {
 
           const params = new SkyAppRuntimeConfigParams(
             currentUrl,
-            this.config.params
+            this.config.params!
           );
 
           const ensureContextArgs: BBContextArgs = {


### PR DESCRIPTION
Recently the Stacktrace team have found issues in their spas/libs that could have been caught earlier by the tsc if `strict` was turned on, particularly `strictNullChecks`. If we try to turn on `strict` in our spas/libs we get errors that originate in skyux-builder because the builder is built in to the spas/libs. This PR aims to do the least amount of work possible to allow consumers to turn on `strict` if they choose.

It fixes the linting issues without changing any functionality or public / private api of skyux builder, mostly by:
- Changing the type with the issues into a union of `undefined`
- Using the [Non-null assertion operator](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#non-null-assertion-operator)