### PR TITLE
Disable aria allowed attr

### DIFF
--- a/config/axe/axe.config.js
+++ b/config/axe/axe.config.js
@@ -50,7 +50,7 @@ const defaults = {
     'bypass': { 'enabled': true },
     'tabindex': { 'enabled': true },
 
-    'aria-allowed-attr': { 'enabled': true },
+    'aria-allowed-attr': { 'enabled': false },
     'aria-required-attr': { 'enabled': true },
     'aria-required-children': { 'enabled': true },
     'aria-required-parent': { 'enabled': true },

--- a/config/axe/axe.config.js
+++ b/config/axe/axe.config.js
@@ -50,7 +50,7 @@ const defaults = {
     'bypass': { 'enabled': true },
     'tabindex': { 'enabled': true },
 
-    // TEMP: this should be re-enabled when we upgrade to axe-core ^3.1.1
+    // TODO: this should be re-enabled when we upgrade to axe-core ^3.1.1 (https://github.com/dequelabs/axe-core/issues/961)
     'aria-allowed-attr': { 'enabled': false },
     'aria-required-attr': { 'enabled': true },
     'aria-required-children': { 'enabled': true },

--- a/config/axe/axe.config.js
+++ b/config/axe/axe.config.js
@@ -50,6 +50,7 @@ const defaults = {
     'bypass': { 'enabled': true },
     'tabindex': { 'enabled': true },
 
+    // TEMP: this should be re-enabled when we upgrade to axe-core ^3.1.1
     'aria-allowed-attr': { 'enabled': false },
     'aria-required-attr': { 'enabled': true },
     'aria-required-children': { 'enabled': true },


### PR DESCRIPTION
This should remain disabled until we can upgrade to using axe-core 3.1.1. The current version does not recognize certain attributes as appropriate for certain roles that we use together and will cause failures to this rule.