### PR TITLE
Added plugins hook to library bundler

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
   nodejs_version: "6"
 
 install:
-  - choco install googlechrome
+  - choco install googlechrome --ignore-checksums
   - ps: Install-Product node $env:nodejs_version
   - npm install
 

--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -101,6 +101,14 @@ export class SkyLibPlaceholderModule {}
   });
 }
 
+function processFiles(skyPagesConfig) {
+  const pluginFileProcessor = require('../lib/plugin-file-processor');
+  pluginFileProcessor.processFiles(
+    skyPagesConfig,
+    skyPagesConfigUtil.spaPathTemp('**', '*.*')
+  );
+}
+
 /**
  * Creates a UMD JavaScript bundle.
  * @param {*} skyPagesConfig
@@ -150,6 +158,7 @@ module.exports = (skyPagesConfig, webpack) => {
   writeTSConfig();
   writePlaceholderModule();
   copyRuntime();
+  processFiles(skyPagesConfig);
 
   return createBundle(skyPagesConfig, webpack)
     .then(() => transpile())

--- a/lib/plugin-file-processor.js
+++ b/lib/plugin-file-processor.js
@@ -7,8 +7,11 @@ const glob = require('glob');
 const skyPagesConfigUtil = require('../config/sky-pages/sky-pages.config');
 const processor = require('../loader/sky-processor');
 
-const processFiles = (skyPagesConfig) => {
-  const filePaths = glob.sync(skyPagesConfigUtil.spaPathTempSrc('app', '**', '*.*'), {
+const processFiles = (
+  skyPagesConfig,
+  rootDir = skyPagesConfigUtil.spaPathTempSrc('app', '**', '*.*')
+) => {
+  const filePaths = glob.sync(rootDir, {
     nodir: true
   });
 

--- a/test/cli-build-public-library.spec.js
+++ b/test/cli-build-public-library.spec.js
@@ -12,6 +12,7 @@ describe('cli build-public-library', () => {
   let mockWebpack;
   let mockFs;
   let mockSpawn;
+  let mockPluginFileProcessor;
 
   beforeEach(() => {
     mockFs = {
@@ -40,6 +41,11 @@ describe('cli build-public-library', () => {
         }
       };
     };
+
+    mockPluginFileProcessor = {
+      processFiles: () => {}
+    };
+
     mock('../cli/utils/ts-linter', {
       lintSync: () => {
         return {
@@ -58,6 +64,7 @@ describe('cli build-public-library', () => {
       }
     });
 
+    mock('../lib/plugin-file-processor', mockPluginFileProcessor);
     mock('fs-extra', mockFs);
     mock('cross-spawn', mockSpawn);
 
@@ -189,6 +196,16 @@ export class SkyLibPlaceholderModule {}
       expect(spy).toHaveBeenCalledWith(
         new Error(`Angular compiler (ngc) exited with status code 1.`)
       );
+      done();
+    });
+  });
+
+  it('should process files', (done) => {
+    const cliCommand = mock.reRequire(requirePath);
+    const spy = spyOn(mockPluginFileProcessor, 'processFiles').and.callThrough();
+
+    cliCommand({}, mockWebpack).then(() => {
+      expect(spy).toHaveBeenCalled();
       done();
     });
   });

--- a/test/plugin-file-processor.spec.js
+++ b/test/plugin-file-processor.spec.js
@@ -73,4 +73,11 @@ describe('SKY UX plugin file processor', () => {
     processor.processFiles(config);
     expect(fs.writeFileSync).not.toHaveBeenCalled();
   });
+
+  it('should allow for a custom root directory', () => {
+    const spy = spyOn(glob, 'sync').and.callThrough();
+    const processor = mock.reRequire(processorPath);
+    processor.processFiles(config, 'foo/bar');
+    expect(spy.calls.argsFor(0)[0]).toEqual('foo/bar');
+  });
 });


### PR DESCRIPTION
- This will allow plugins to affect the `skyux build-public-library` phase.
- Needed to accommodate the synchronous nature of `SkyResources` service.

This is being used, here: https://github.com/blackbaud/skyux-core/pull/31