### PR TITLE
Allow libraries to include an isolated "testing" module

### DIFF
--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -43,6 +43,20 @@ function cleanRuntime() {
   rimraf.sync(skyPagesConfigUtil.spaPath('dist', 'runtime'));
 }
 
+function getEntryPointFiles() {
+  const files = [
+    skyPagesConfigUtil.spaPathTemp('index.ts')
+  ];
+
+  const testingPath = skyPagesConfigUtil.spaPathTemp('testing', 'index.ts');
+
+  if (fs.existsSync(testingPath)) {
+    files.push(testingPath);
+  }
+
+  return files;
+}
+
 function writeTSConfig() {
   var config = {
     'compilerOptions': {
@@ -76,9 +90,7 @@ function writeTSConfig() {
         ]
       }
     },
-    'files': [
-      skyPagesConfigUtil.spaPathTemp('index.ts')
-    ]
+    'files': getEntryPointFiles()
   };
 
   fs.writeJSONSync(skyPagesConfigUtil.spaPathTemp('tsconfig.json'), config);

--- a/cli/build-public-library.js
+++ b/cli/build-public-library.js
@@ -49,7 +49,6 @@ function getEntryPointFiles() {
   ];
 
   const testingPath = skyPagesConfigUtil.spaPathTemp('testing', 'index.ts');
-
   if (fs.existsSync(testingPath)) {
     files.push(testingPath);
   }

--- a/test/cli-build-public-library.spec.js
+++ b/test/cli-build-public-library.spec.js
@@ -18,7 +18,8 @@ describe('cli build-public-library', () => {
     mockFs = {
       writeJSONSync() {},
       writeFileSync() {},
-      copySync() {}
+      copySync() {},
+      existsSync() {}
     };
 
     mockSpawn = {
@@ -70,8 +71,8 @@ describe('cli build-public-library', () => {
 
     spyOn(process, 'exit').and.callFake(() => {});
     spyOn(skyPagesConfigUtil, 'spaPath').and.returnValue('');
-    spyOn(skyPagesConfigUtil, 'spaPathTemp').and.callFake((fileName = '') => {
-      return fileName;
+    spyOn(skyPagesConfigUtil, 'spaPathTemp').and.callFake((...fragments) => {
+      return fragments.join('/');
     });
     spyOn(skyPagesConfigUtil, 'outPath').and.callFake((fileName = '') => {
       return fileName;
@@ -210,5 +211,15 @@ export class SkyLibPlaceholderModule {}
     });
   });
 
-  it('should include testing entry point if directory exists', () => {});
+  it('should include testing entry point if directory exists', (done) => {
+    spyOn(mockFs, 'existsSync').and.returnValue(true);
+    const spy = spyOn(mockFs, 'writeJSONSync').and.callThrough();
+    const cliCommand = mock.reRequire(requirePath);
+    cliCommand({}, mockWebpack).then(() => {
+      expect(spy).toHaveBeenCalled();
+      const files = spy.calls.argsFor(0)[1].files;
+      expect(files[1]).toEqual('testing/index.ts');
+      done();
+    });
+  });
 });

--- a/test/cli-build-public-library.spec.js
+++ b/test/cli-build-public-library.spec.js
@@ -209,4 +209,6 @@ export class SkyLibPlaceholderModule {}
       done();
     });
   });
+
+  it('should include testing entry point if directory exists', () => {});
 });


### PR DESCRIPTION
This will allow libraries to generate two modules in their NPM package: the "production" module (which is consumed by the SPA, and a "testing" module, which is used by the consuming SPA's unit tests.

```
import {
  MyTestingModule
} from '@skyux/core/testing';
```

The library must include a "testing" directory in `./src/app/public` folder.

We need to include a separate file for the testing module so that its contents don't "pollute" the production module during a webpack build.