### PR TITLE
Update version of `@skyux/i18n`

### DIFF
--- a/lib/sky-pages-module-generator.js
+++ b/lib/sky-pages-module-generator.js
@@ -90,7 +90,17 @@ function getSource(skyAppConfig) {
   let authTokenProvider = 'SkyAuthTokenProvider';
 
   if (skyAppConfig.runtime.command === 'pact') {
-    nodeModuleImports.push(`import { SkyPactModule } from '@skyux-sdk/pact';`);
+    nodeModuleImports.push(
+      `import { SkyPactAuthTokenProvider, SkyPactService } from '@skyux-sdk/pact';`
+    );
+    runtimeProviders
+      .push(`{
+        provide: SkyPactService,
+        useClass: SkyPactService,
+        deps: [SkyAppConfig]
+      }`);
+    runtimeImports.push('SkyPactAuthTokenProvider');
+    runtimeImports.push('SkyPactService');
     authTokenProvider = `{
       provide: SkyAuthTokenProvider,
       useClass: SkyPactAuthTokenProvider
@@ -100,7 +110,13 @@ function getSource(skyAppConfig) {
   runtimeProviders.push(authTokenProvider);
 
   if (skyAppConfig.skyux.auth) {
-    nodeModuleImports.push(`import { SkyAuthHttpModule } from '@skyux/http';`);
+    nodeModuleImports.push(`import { XHRBackend, RequestOptions } from '@angular/http';`);
+    nodeModuleImports.push(`import { SkyAuthHttp } from '@skyux/http';`);
+    runtimeProviders.push(`{
+      provide: SkyAuthHttp,
+      useClass: SkyAuthHttp,
+      deps: [XHRBackend, RequestOptions, SkyAuthTokenProvider, SkyAppConfig]
+    }`);
   }
 
   if (skyAppConfig.skyux.help) {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@skyux/assets": "3.0.0",
     "@skyux/config": "3.0.0",
     "@skyux/http": "3.0.0",
-    "@skyux/i18n": "3.0.0",
+    "@skyux/i18n": "3.0.1",
     "@skyux/omnibar-interop": "3.0.0",
     "@skyux/router": "3.0.0",
     "@types/core-js": "0.9.41",

--- a/test/sky-pages-module-generator.spec.js
+++ b/test/sky-pages-module-generator.spec.js
@@ -194,7 +194,12 @@ describe('SKY UX Builder module generator', () => {
 
   it('should only import the SkyAuthHttpModule if the app is configured to use auth', () => {
     const generator = mock.reRequire(GENERATOR_PATH);
-    const expectedImport = `SkyAuthHttpModule`;
+    const expectedImport = `{ SkyAuthHttp }`;
+    const expectedProvider = `{
+      provide: SkyAuthHttp,
+      useClass: SkyAuthHttp,
+      deps: [XHRBackend, RequestOptions, SkyAuthTokenProvider, SkyAppConfig]
+    }`;
 
     let source = generator.getSource({
       runtime: runtimeUtils.getDefaultRuntime(),
@@ -202,6 +207,7 @@ describe('SKY UX Builder module generator', () => {
     });
 
     expect(source).not.toContain(expectedImport);
+    expect(source).not.toContain(expectedProvider);
 
     source = generator.getSource({
       runtime: runtimeUtils.getDefaultRuntime(),
@@ -211,6 +217,7 @@ describe('SKY UX Builder module generator', () => {
     });
 
     expect(source).toContain(expectedImport);
+    expect(source).toContain(expectedProvider);
   });
 
   it('should not add BBHelpModule if the help config does not exists.', () => {
@@ -367,7 +374,7 @@ BBAuth.mock = true;`);
     expect(source).toContain('routing = RouterModule.forRoot(routes, { useHash: false });');
   });
 
-  it('should add SkyPactModule and override AuthTokenProvider if calling pact command', () => {
+  it('should add SkyPactService and override AuthTokenProvider if calling pact command', () => {
     const generator = mock.reRequire(GENERATOR_PATH);
     let runtime = runtimeUtils.getDefaultRuntime();
     runtime.command = 'pact';
@@ -377,8 +384,11 @@ BBAuth.mock = true;`);
       skyux: runtimeUtils.getDefaultSkyux()
     });
 
-    expect(source).toContain(`SkyPactModule`);
+    expect(source).toContain(`provide: SkyPactService`);
+    expect(source).toContain(`useClass: SkyPactService`);
+    expect(source).toContain(`deps: [SkyAppConfig]`);
     expect(source).toContain('SkyPactAuthTokenProvider');
+    expect(source).toContain('SkyPactService');
     expect(source).toContain(`{
       provide: SkyAuthTokenProvider,
       useClass: SkyPactAuthTokenProvider


### PR DESCRIPTION
@Blackbaud-BobbyEarl I reverted some changes I made to the `sky-pages-module-generator`. I've tested this branch on skyux2 and a few internal SPAs.

This solves two problems:
1. Fixes the `No provider for SkyAuthHttp!` error.
2. I've updated `@skyux/i18n` to fix another problem that only occurred during unit tests. See: https://github.com/blackbaud/skyux-i18n/pull/11