### PR TITLE
Use local source for e2e tests

### DIFF
--- a/config/protractor/protractor-dev.conf.js
+++ b/config/protractor/protractor-dev.conf.js
@@ -61,9 +61,35 @@ let config = {
               spaPkgJson.dependencies[dep] = builderPkgJson.dependencies[dep];
             });
 
+            // Remove any installed versions of Builder.
+            delete spaPkgJson.devDependencies['@blackbaud/skyux-builder'];
+
             fs.writeJsonSync(spaPkgPath, spaPkgJson, { spaces: 2 });
           })
           .then(() => common.exec(`npm`, [`i`], common.cwdOpts))
+          .then(() => {
+            // Copy builder's source to node_modules.
+            const files = [
+              'cli',
+              'config',
+              'e2e',
+              'lib',
+              'loader',
+              'plugin',
+              'runtime',
+              'src',
+              'ssl',
+              'utils',
+              'index.js',
+              'package.json',
+              'skyuxconfig.json',
+              'tsconfig.json',
+              'tslint.json'
+            ];
+            files.forEach((file) => {
+              fs.copySync(file, `.e2e-tmp/node_modules/@blackbaud/skyux-builder/${file}`);
+            });
+          })
           .then(resolve)
           .catch(reject);
 

--- a/config/protractor/protractor-dev.conf.js
+++ b/config/protractor/protractor-dev.conf.js
@@ -68,7 +68,7 @@ let config = {
           })
           .then(() => common.exec(`npm`, [`i`], common.cwdOpts))
           .then(() => {
-            // Copy builder's source to node_modules.
+            // Copy builder's local source to node_modules.
             const files = [
               'cli',
               'config',
@@ -86,8 +86,15 @@ let config = {
               'tsconfig.json',
               'tslint.json'
             ];
-            files.forEach((file) => {
-              fs.copySync(file, `.e2e-tmp/node_modules/@blackbaud/skyux-builder/${file}`);
+
+            files.forEach(file => {
+              fs.copySync(
+                file,
+                path.resolve(
+                  common.tmp,
+                  `node_modules/@blackbaud/skyux-builder/${file}`
+                )
+              );
             });
           })
           .then(resolve)


### PR DESCRIPTION
Builder's internal e2e tests do not use the local source for `@blackbaud/skyux-builder`. This pull request fixes that.