### PR TITLE
Provide Angular's `LOCALE_ID`

### DIFF
--- a/lib/sky-pages-module-generator.js
+++ b/lib/sky-pages-module-generator.js
@@ -90,11 +90,16 @@ function getSource(skyAppConfig) {
       provide: SkyAppLocaleProvider,
       useClass: SkyAppHostLocaleProvider
     }`,
+    `{
+      provide: LOCALE_ID,
+      deps: [SkyAppLocaleProvider],
+      useFactory: skyLocaleIdFactory
+    }`,
     'SkyAppViewportService'
   ];
 
   let nodeModuleImports = [
-    `import { Component, NgModule, OnDestroy, OnInit } from '@angular/core';`,
+    `import { Component, LOCALE_ID, NgModule, OnDestroy, OnInit } from '@angular/core';`,
     `import { CommonModule } from '@angular/common';`,
     `import { HttpModule } from '@angular/http';`,
     `import { FormsModule, ReactiveFormsModule } from '@angular/forms';`,
@@ -217,6 +222,10 @@ export function SkyAppConfigFactory(windowRef: SkyAppWindowRef): any {
     ${JSON.stringify(skyAppConfig.skyux.params)}
   );
   return config;
+}
+
+export function skyLocaleIdFactory(localeProvider: SkyAppLocaleProvider) {
+  return localeProvider.currentLocale;
 }
 
 // Setting skyux config as static property exclusively for Bootstrapper

--- a/runtime/i18n/host-locale-provider.spec.ts
+++ b/runtime/i18n/host-locale-provider.spec.ts
@@ -3,14 +3,17 @@ import {
 } from './host-locale-provider';
 
 describe('Host locale provider', () => {
+  let mockWindowRef: any;
 
-  const mockWindowRef: any = {
-    nativeWindow: {
-      SKYUX_HOST: {
-        acceptLanguage: 'en-GB'
+  beforeEach(() => {
+    mockWindowRef = {
+      nativeWindow: {
+        SKYUX_HOST: {
+          acceptLanguage: 'en-GB'
+        }
       }
-    }
-  };
+    };
+  });
 
   it('should get locale info from the global SKYUX_HOST variable', (done) => {
     const localeProvider = new SkyAppHostLocaleProvider(mockWindowRef);
@@ -35,4 +38,9 @@ describe('Host locale provider', () => {
       });
     }
   );
+
+  it('should expose the current locale synchronously', () => {
+    const localeProvider = new SkyAppHostLocaleProvider(mockWindowRef);
+    expect(localeProvider.currentLocale).toBe('en-GB');
+  });
 });

--- a/runtime/i18n/host-locale-provider.ts
+++ b/runtime/i18n/host-locale-provider.ts
@@ -37,8 +37,6 @@ export class SkyAppHostLocaleProvider extends SkyAppLocaleProvider {
     return locale;
   }
 
-  private currentLocaleInfo: SkyAppLocaleInfo;
-
   constructor(
     private windowRef: SkyAppWindowRef
   ) {
@@ -46,14 +44,10 @@ export class SkyAppHostLocaleProvider extends SkyAppLocaleProvider {
   }
 
   public getLocaleInfo(): Observable<SkyAppLocaleInfo> {
-    if (this.currentLocaleInfo) {
-      return Observable.of(this.currentLocaleInfo);
-    }
-
-    this.currentLocaleInfo = {
+    const localeInfo: SkyAppLocaleInfo = {
       locale: this.currentLocale
     };
 
-    return Observable.of(this.currentLocaleInfo);
+    return Observable.of(localeInfo);
   }
 }

--- a/runtime/i18n/host-locale-provider.ts
+++ b/runtime/i18n/host-locale-provider.ts
@@ -10,6 +10,8 @@ import {
   Observable
 } from 'rxjs/Observable';
 
+import 'rxjs/add/observable/of';
+
 import {
   SkyAppLocaleInfo
 } from './locale-info';
@@ -20,13 +22,7 @@ import {
 
 @Injectable()
 export class SkyAppHostLocaleProvider extends SkyAppLocaleProvider {
-  constructor(
-    private windowRef: SkyAppWindowRef
-  ) {
-    super();
-  }
-
-  public getLocaleInfo(): Observable<SkyAppLocaleInfo> {
+  public get currentLocale(): string {
     let locale: string | undefined;
 
     const skyuxHost = (this.windowRef.nativeWindow as any).SKYUX_HOST;
@@ -38,8 +34,26 @@ export class SkyAppHostLocaleProvider extends SkyAppLocaleProvider {
 
     locale = locale || this.defaultLocale;
 
-    return Observable.of({
-      locale: locale
-    });
+    return locale;
+  }
+
+  private currentLocaleInfo: SkyAppLocaleInfo;
+
+  constructor(
+    private windowRef: SkyAppWindowRef
+  ) {
+    super();
+  }
+
+  public getLocaleInfo(): Observable<SkyAppLocaleInfo> {
+    if (this.currentLocaleInfo) {
+      return Observable.of(this.currentLocaleInfo);
+    }
+
+    this.currentLocaleInfo = {
+      locale: this.currentLocale
+    };
+
+    return Observable.of(this.currentLocaleInfo);
   }
 }


### PR DESCRIPTION
This pull request requires a change to `@skyux/i18n`.
See: https://github.com/blackbaud/skyux-i18n/pull/22

Purpose: This change will automatically set Angular's `LOCALE_ID` based on what's provided by `SkyAppHostLocaleProvider`. The side effect is that Angular's `DatePipe` (and any other localized utilities) will be automatically provided with the same locale string.