### PR TITLE
Add module aliases

### DIFF
--- a/config/webpack/alias-builder.js
+++ b/config/webpack/alias-builder.js
@@ -48,6 +48,14 @@ module.exports = {
       alias['@blackbaud/skyux/dist'] = spaPath(skyPagesConfig.skyux.importPath);
     }
 
+    // Allow SPAs to provide custom module aliases.
+    const moduleAliases = skyPagesConfig.skyux.moduleAliases;
+    if (moduleAliases) {
+      Object.keys(moduleAliases).forEach((key) => {
+        alias[key] = spaPath(moduleAliases[key]);
+      });
+    }
+
     setSpaAlias(
       alias,
       'src/app/app-extras.module',

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@skyux-sdk/pact": "3.0.1",
     "@skyux-sdk/testing": "3.0.0",
     "@skyux/assets": "3.0.0",
-    "@skyux/config": "3.3.0",
+    "@skyux/config": "3.5.0",
     "@skyux/http": "3.2.0",
     "@skyux/i18n": "3.5.0",
     "@skyux/omnibar-interop": "3.1.0",

--- a/test/config-webpack-common.spec.js
+++ b/test/config-webpack-common.spec.js
@@ -169,4 +169,21 @@ describe('config webpack common', () => {
     expect(plugin.calls.first().args[0].color).toEqual(true);
   });
 
+  it('should allow for custom alias resolution', () => {
+    const lib = mock.reRequire('../config/webpack/common.webpack.config');
+
+    const config = lib.getWebpackConfig({
+      runtime: runtimeUtils.getDefaultRuntime(),
+      skyux: {
+        moduleAliases: {
+          '@skyux/foo': './src/app/public'
+        }
+      }
+    });
+
+    const alias = config.resolve.alias;
+
+    expect(alias['@skyux/foo']).toBe(path.join(process.cwd(), './src/app/public'));
+  });
+
 });


### PR DESCRIPTION
Related: https://github.com/blackbaud/skyux-config/pull/16
SDK Builder, too: https://github.com/blackbaud/skyux-sdk-builder/pull/56

@Blackbaud-BobbyEarl We need to add this feature to Builder `1.x` because our libraries are still using it to maintain backwards compatibility with SKY UX 2.