### PR TITLE
Disallow fit and fdescribe

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
   "rulesDirectory": [
-    "codelyzer"
+      "codelyzer",
+      "tslint/rules"
   ],
   "rules": {
     "member-access": true,
@@ -148,6 +149,7 @@
     "use-pipe-transform-interface": true,
     "pipe-naming": [true, "camelCase", "sky"],
     "component-class-suffix": true,
-    "directive-class-suffix": true
+    "directive-class-suffix": true,
+    "no-jasmine-focus": true      
   }
 }

--- a/tslint/rules/noJasmineFocusRule.js
+++ b/tslint/rules/noJasmineFocusRule.js
@@ -1,0 +1,56 @@
+const ts = require('typescript');
+const Lint = require('tslint');
+
+/**
+ * TSLint Check to disallow fdescribe and fit
+ * 
+ * Usage in tslint.json: "no-jasmine-focus": true
+ */
+class Rule extends Lint.Rules.AbstractRule {
+  /**
+   * @param {ts.SourceFile} sourceFile
+   * @return {RuleFailure[]}
+   */
+  apply(sourceFile) {
+    return this.applyWithWalker(new JasmineWalker(sourceFile, this.getOptions()));
+  }
+}
+
+class JasmineWalker extends Lint.RuleWalker {
+  /**
+   * @param {ts.SourceFile} sourceFile
+   * @param {IOptions} options
+   */
+  constructor(sourceFile, options) {
+    super(sourceFile, options);
+
+    this.disallowedFunctionNames = [
+      'fdescribe',
+      'fit'
+    ];
+  }
+
+  /**
+   * Callback that is called by tslint when an identifier is called
+   * The identifier are the called functions
+   *
+   * @param {ts.Identifier} node
+   */
+  visitIdentifier(node) {
+    if (this.isFunctionNameDisallowed(node.text)) {
+      this.addFailure(this.createFailure(node.getStart(), node.getWidth(), `${node.text} not allowed`));
+    }
+  }
+
+  /**
+   * Check if a given function is not allowed
+   *
+   * @param {string} functionName
+   * @return {boolean}
+   */
+  isFunctionNameDisallowed(functionName) {
+    return this.disallowedFunctionNames.indexOf(functionName) !== -1;
+  }
+}
+
+exports.Rule = Rule;


### PR DESCRIPTION
I've been bitten too many times by forgetting to remove `f`s before committing. This PR adds a rule that disallows `fit` and `fdescribe`. Most importantly, you can still run `skyux test` when you have `fit` and `fdescribe`. You'll get errors in your terminal but the focused tests will still run.